### PR TITLE
Restore Lakeshore GPIB functionality

### DIFF
--- a/pychron/hardware/core/communicators/gpib_communicator.py
+++ b/pychron/hardware/core/communicators/gpib_communicator.py
@@ -49,10 +49,10 @@ class GpibCommunicator(Communicator):
     def trigger(self):
         self.handle.trigger()
 
-    def ask(self, cmd):
+    def ask(self, cmd, verbose=False):
         return self.handle.query(cmd)
 
-    def tell(self, cmd):
+    def tell(self, cmd, verbose=False):
         self.handle.write(cmd)
 
 # address = 16

--- a/pychron/hardware/core/communicators/gpib_communicator.py
+++ b/pychron/hardware/core/communicators/gpib_communicator.py
@@ -50,7 +50,7 @@ class GpibCommunicator(Communicator):
         self.handle.trigger()
 
     def ask(self, cmd):
-        return self.handle.ask(cmd)
+        return self.handle.query(cmd)
 
     def tell(self, cmd):
         self.handle.write(cmd)

--- a/pychron/hardware/core/scanable_device.py
+++ b/pychron/hardware/core/scanable_device.py
@@ -105,7 +105,7 @@ class ScanableDevice(ViewableDevice):
         if self.scan_func:
 
             try:
-                v = getattr(self, self.scan_func)(verbose=False)
+                v = getattr(self, self.scan_func)()
             except AttributeError as e:
                 print('exception', e)
                 return

--- a/pychron/hardware/lakeshore/base_controller.py
+++ b/pychron/hardware/lakeshore/base_controller.py
@@ -122,8 +122,8 @@ class BaseLakeShoreController(CoreDevice):
             setattr(self, '{}_readback'.format(tag), v)
         return self._update_hook()
 
-    # def _update_hook(self):
-    #     return self.input_a
+    def _update_hook(self):
+        return self.input_a
 
     def setpoints_achieved(self, tol=1):
         for i, (tag, key) in enumerate(zip(self.iomap, string.ascii_lowercase)):
@@ -141,7 +141,7 @@ class BaseLakeShoreController(CoreDevice):
     @get_float(default=0)
     def read_setpoint(self, output, verbose=False):
         if output is not None:
-            return self.ask('SETP? {}'.format(re.sub('[^0-9]', '', output)))
+            return self.ask('SETP? {}'.format(re.sub('[^0-9]', '', output)), verbose=verbose)
 
     def set_setpoints(self, *setpoints, block=False, delay=1):
         for i, v in enumerate(setpoints):
@@ -192,8 +192,8 @@ class BaseLakeShoreController(CoreDevice):
         return self._read_input('b', self.units, **kw)
 
     @get_float(default=0)
-    def _read_input(self, tag, mode='C'):
-        return self.ask('{}RDG? {}'.format(mode, tag))
+    def _read_input(self, tag, mode='C', verbose=False):
+        return self.ask('{}RDG? {}'.format(mode, tag), verbose=verbose)
 
     def _setpoint1_changed(self):
         self.set_setpoint(self.setpoint1, 1)
@@ -203,7 +203,6 @@ class BaseLakeShoreController(CoreDevice):
 
     def _update_hook(self):
         r = PlotRecord((self.input_a, self.input_b), (0, 1), ('a', 'b'))
-        print('second update hook')
         return r
 
     def get_control_group(self):

--- a/pychron/hardware/lakeshore/base_controller.py
+++ b/pychron/hardware/lakeshore/base_controller.py
@@ -122,8 +122,8 @@ class BaseLakeShoreController(CoreDevice):
             setattr(self, '{}_readback'.format(tag), v)
         return self._update_hook()
 
-    def _update_hook(self):
-        return self.input_a
+    # def _update_hook(self):
+    #     return self.input_a
 
     def setpoints_achieved(self, tol=1):
         for i, (tag, key) in enumerate(zip(self.iomap, string.ascii_lowercase)):
@@ -141,7 +141,7 @@ class BaseLakeShoreController(CoreDevice):
     @get_float(default=0)
     def read_setpoint(self, output, verbose=False):
         if output is not None:
-            return self.ask('SETP? {}'.format(re.sub('[^0-9]', '', output)), verbose=verbose)
+            return self.ask('SETP? {}'.format(re.sub('[^0-9]', '', output)))
 
     def set_setpoints(self, *setpoints, block=False, delay=1):
         for i, v in enumerate(setpoints):
@@ -192,8 +192,8 @@ class BaseLakeShoreController(CoreDevice):
         return self._read_input('b', self.units, **kw)
 
     @get_float(default=0)
-    def _read_input(self, tag, mode='C', verbose=False):
-        return self.ask('{}RDG? {}'.format(mode, tag), verbose=verbose)
+    def _read_input(self, tag, mode='C'):
+        return self.ask('{}RDG? {}'.format(mode, tag))
 
     def _setpoint1_changed(self):
         self.set_setpoint(self.setpoint1, 1)
@@ -203,6 +203,7 @@ class BaseLakeShoreController(CoreDevice):
 
     def _update_hook(self):
         r = PlotRecord((self.input_a, self.input_b), (0, 1), ('a', 'b'))
+        print('second update hook')
         return r
 
     def get_control_group(self):


### PR DESCRIPTION
1) GPIBInstrument from pyvisa has no ask (should be query) in GPIB Communicator. 2) GPIB Communicator does not accept ‘verbose’ keyword, so removed from base_controller. 3) Calling the update method with getattr in scanable_device returns the method, so () is needed to actually call the function. I’m not sure if this is a python 3 change.