### PR TITLE
Fix experiment hang in WaitControl: rearchitect timing off the Qt event loop

### DIFF
--- a/pychron/core/wait/tests/test_wait_group.py
+++ b/pychron/core/wait/tests/test_wait_group.py
@@ -1,0 +1,72 @@
+import threading
+import time
+import unittest
+
+from pychron.core.wait.wait_control import WaitControl
+from pychron.core.wait.wait_group import WaitGroup
+
+
+class WaitGroupStartWaitTestCase(unittest.TestCase):
+    """Integration: prove the experiment thread does NOT depend on Qt to make
+    progress. These tests run with no QApplication, so any code path that
+    requires Qt to fire would hang or fail."""
+
+    def test_blocking_wait_completes_at_deadline_without_qt(self) -> None:
+        wg = WaitGroup()
+        wc = WaitControl()
+        wg.controls = [wc]
+
+        t0 = time.monotonic()
+        outcome = wg.start_wait(wc, duration=0.2)
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(outcome, "completed")
+        self.assertGreaterEqual(elapsed, 0.18)
+        self.assertLess(elapsed, 0.6)
+
+    def test_continue_from_other_thread_unblocks_wait_quickly(self) -> None:
+        wg = WaitGroup()
+        wc = WaitControl()
+        wg.controls = [wc]
+
+        def trigger():
+            time.sleep(0.05)
+            wc.continue_wait()
+
+        threading.Thread(target=trigger, daemon=True).start()
+
+        t0 = time.monotonic()
+        outcome = wg.start_wait(wc, duration=10.0)
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(outcome, "continued")
+        self.assertLess(elapsed, 0.5)
+
+    def test_stop_from_other_thread_cancels_wait(self) -> None:
+        wg = WaitGroup()
+        wc = WaitControl()
+        wg.controls = [wc]
+
+        def trigger():
+            time.sleep(0.05)
+            wc.stop()
+
+        threading.Thread(target=trigger, daemon=True).start()
+
+        outcome = wg.start_wait(wc, duration=10.0)
+        self.assertEqual(outcome, "canceled")
+        self.assertTrue(wc.is_canceled())
+
+    def test_nonblocking_returns_none(self) -> None:
+        wg = WaitGroup()
+        wc = WaitControl()
+        wg.controls = [wc]
+
+        result = wg.start_wait(wc, duration=10.0, block=False)
+        self.assertIsNone(result)
+        # Cleanup so the test doesn't leave a dangling running state.
+        wc.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/core/wait/tests/test_wait_state.py
+++ b/pychron/core/wait/tests/test_wait_state.py
@@ -1,0 +1,242 @@
+import threading
+import time
+import unittest
+
+from pychron.core.wait.wait_state import (
+    CANCELED,
+    COMPLETED,
+    CONTINUED,
+    IDLE,
+    RUNNING,
+    WaitState,
+)
+
+
+def _run_in_thread(target, *args, **kw):
+    """Start `target` in a daemon thread; return the thread."""
+    t = threading.Thread(target=target, args=args, kwargs=kw, daemon=True)
+    t.start()
+    return t
+
+
+class WaitStateBasicsTestCase(unittest.TestCase):
+    def test_initial_outcome_is_idle(self) -> None:
+        s = WaitState()
+        self.assertEqual(s.outcome, IDLE)
+        snap = s.snapshot()
+        self.assertEqual(snap.outcome, IDLE)
+        self.assertEqual(snap.remaining, 0.0)
+
+    def test_start_transitions_to_running(self) -> None:
+        s = WaitState()
+        s.start(5.0, message="hello")
+
+        self.assertEqual(s.outcome, RUNNING)
+        snap = s.snapshot()
+        self.assertEqual(snap.outcome, RUNNING)
+        self.assertAlmostEqual(snap.remaining, 5.0, delta=0.05)
+        self.assertEqual(snap.message, "hello")
+        self.assertFalse(snap.paused)
+        self.assertEqual(snap.duration, 5.0)
+
+
+class WaitStateCompletionTestCase(unittest.TestCase):
+    def test_wait_returns_completed_at_deadline(self) -> None:
+        s = WaitState()
+        s.start(0.2)
+
+        t0 = time.monotonic()
+        outcome = s.wait()
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(outcome, COMPLETED)
+        # Wait should sleep ~duration; allow generous slack on slow CI.
+        self.assertGreaterEqual(elapsed, 0.18)
+        self.assertLess(elapsed, 0.6)
+
+    def test_wait_returns_immediately_if_already_resolved(self) -> None:
+        s = WaitState()
+        s.start(10.0)
+        s.request_continue()
+
+        t0 = time.monotonic()
+        outcome = s.wait()
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(outcome, CONTINUED)
+        self.assertLess(elapsed, 0.05)
+
+
+class WaitStateContinueTestCase(unittest.TestCase):
+    def test_continue_interrupts_wait_quickly(self) -> None:
+        s = WaitState()
+        s.start(10.0)
+
+        results: dict = {}
+
+        def waiter():
+            results["outcome"] = s.wait()
+            results["elapsed"] = time.monotonic() - results["t0"]
+
+        results["t0"] = time.monotonic()
+        t = _run_in_thread(waiter)
+        # Let the waiter actually enter wait().
+        time.sleep(0.05)
+        s.request_continue()
+        t.join(timeout=1.0)
+
+        self.assertFalse(t.is_alive(), "waiter did not return")
+        self.assertEqual(results["outcome"], CONTINUED)
+        self.assertLess(results["elapsed"], 0.3)
+
+    def test_continue_after_completion_is_noop(self) -> None:
+        s = WaitState()
+        s.start(0.05)
+        outcome = s.wait()
+        self.assertEqual(outcome, COMPLETED)
+
+        # Late continue should not flip outcome away from COMPLETED.
+        s.request_continue()
+        self.assertEqual(s.outcome, COMPLETED)
+
+
+class WaitStateCancelTestCase(unittest.TestCase):
+    def test_cancel_interrupts_wait(self) -> None:
+        s = WaitState()
+        s.start(10.0)
+
+        results: dict = {}
+
+        def waiter():
+            results["outcome"] = s.wait()
+
+        t = _run_in_thread(waiter)
+        time.sleep(0.05)
+        s.request_cancel()
+        t.join(timeout=1.0)
+
+        self.assertFalse(t.is_alive())
+        self.assertEqual(results["outcome"], CANCELED)
+        self.assertTrue(s.is_canceled())
+
+
+class WaitStatePauseTestCase(unittest.TestCase):
+    def test_pause_extends_deadline_by_pause_duration(self) -> None:
+        s = WaitState()
+        s.start(0.4)
+
+        # Wait a bit, then pause, hold, then resume — total wait should be
+        # approximately duration + pause_hold.
+        t0 = time.monotonic()
+
+        def runner():
+            time.sleep(0.1)
+            s.request_pause(True)
+            time.sleep(0.3)         # held while paused; should not count
+            s.request_pause(False)
+
+        ctrl = _run_in_thread(runner)
+        outcome = s.wait()
+        elapsed = time.monotonic() - t0
+        ctrl.join(timeout=1.0)
+
+        self.assertEqual(outcome, COMPLETED)
+        # Expect ~ 0.4 + 0.3 = 0.7s; allow slack.
+        self.assertGreaterEqual(elapsed, 0.6)
+        self.assertLess(elapsed, 1.2)
+
+    def test_snapshot_remaining_is_frozen_while_paused(self) -> None:
+        s = WaitState()
+        s.start(2.0)
+        time.sleep(0.05)
+        s.request_pause(True)
+
+        first = s.snapshot().remaining
+        time.sleep(0.1)
+        second = s.snapshot().remaining
+
+        self.assertTrue(first > 0)
+        self.assertAlmostEqual(first, second, delta=0.01)
+        self.assertTrue(s.snapshot().paused)
+
+    def test_continue_while_paused_resolves(self) -> None:
+        s = WaitState()
+        s.start(10.0)
+        s.request_pause(True)
+
+        results: dict = {}
+
+        def waiter():
+            results["outcome"] = s.wait()
+
+        t = _run_in_thread(waiter)
+        time.sleep(0.05)
+        s.request_continue()
+        t.join(timeout=1.0)
+
+        self.assertFalse(t.is_alive(), "paused waiter did not wake on continue")
+        self.assertEqual(results["outcome"], CONTINUED)
+
+
+class WaitStateMessageTestCase(unittest.TestCase):
+    def test_set_message_visible_in_snapshot(self) -> None:
+        s = WaitState()
+        s.start(1.0, message="initial")
+        self.assertEqual(s.snapshot().message, "initial")
+
+        s.set_message("updated")
+        self.assertEqual(s.snapshot().message, "updated")
+
+    def test_set_remaining_extends_deadline(self) -> None:
+        s = WaitState()
+        s.start(0.1)
+        s.set_remaining(0.5)
+
+        t0 = time.monotonic()
+        outcome = s.wait()
+        elapsed = time.monotonic() - t0
+
+        self.assertEqual(outcome, COMPLETED)
+        self.assertGreaterEqual(elapsed, 0.4)
+
+
+class WaitStateConcurrencyTestCase(unittest.TestCase):
+    def test_many_concurrent_button_presses_resolve_to_one_outcome(self) -> None:
+        """Hammer continue/cancel from many threads; final outcome must be
+        deterministic (whichever request_* won), and wait() must return."""
+        s = WaitState()
+        s.start(5.0)
+
+        outcomes: list = []
+
+        def waiter():
+            outcomes.append(s.wait())
+
+        t = _run_in_thread(waiter)
+        time.sleep(0.02)
+
+        threads = []
+        for i in range(20):
+            target = s.request_continue if i % 2 == 0 else s.request_cancel
+            threads.append(_run_in_thread(target))
+        for x in threads:
+            x.join(timeout=1.0)
+        t.join(timeout=1.0)
+
+        self.assertFalse(t.is_alive())
+        self.assertEqual(len(outcomes), 1)
+        self.assertIn(outcomes[0], (CONTINUED, CANCELED))
+
+    def test_restart_resets_to_running(self) -> None:
+        s = WaitState()
+        s.start(0.05)
+        self.assertEqual(s.wait(), COMPLETED)
+
+        s.start(0.05, message="round 2")
+        self.assertEqual(s.snapshot().message, "round 2")
+        self.assertEqual(s.outcome, RUNNING)
+        self.assertEqual(s.wait(), COMPLETED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pychron/core/wait/wait_control.py
+++ b/pychron/core/wait/wait_control.py
@@ -13,20 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+"""WaitControl: TraitsUI façade for a single wait.
+
+Architecture (rewritten 2026):
+    WaitState  -- pure-Python timing truth (no Qt). Lives in wait_state.py.
+                  Experiment thread blocks on state.wait(); UI never blocks
+                  experiment progress.
+    WaitControl -- HasTraits façade. Owns a WaitState plus a Qt polling timer
+                  that mirrors snapshots into Traits so all existing
+                  ``object.wait_control.<trait>`` UI bindings keep working.
+
+The polling timer is purely cosmetic. If the main Qt event loop is busy,
+the displayed countdown lags briefly; the experiment thread is unaffected
+because it is blocking on a threading.Event with timeout, not on Qt.
+"""
 
 # ============= standard library imports ========================
-from threading import current_thread
-from typing import Any, Callable
+from threading import Thread, current_thread
+from typing import Any, Callable, Optional
 
 # ============= enthought library imports =======================
 from pyface.qt.QtCore import QTimer
 from pyface.qt.QtWidgets import QApplication
-from traits.api import Str, Button, Float, Bool, Property, Int, Event as TEvent
 from pyface.ui_traits import PyfaceColor
+from traits.api import Bool, Button, Event as TEvent, Float, Int, Property, Str
 
 # ============= local library imports  ==========================
 from pychron.core.helpers.ctx_managers import no_update
+from pychron.core.ui.gui import invoke_in_main_thread
+from pychron.core.wait.wait_state import (
+    CANCELED,
+    COMPLETED,
+    CONTINUED,
+    IDLE,
+    RUNNING,
+    WaitState,
+    WaitSnapshot,
+)
 from pychron.loggable import Loggable
+
+_POLL_INTERVAL_MS = 100
 
 
 class WaitControl(Loggable):
@@ -42,241 +68,118 @@ class WaitControl(Loggable):
     current_display_time = Property(depends_on="current_time")
 
     auto_start = Bool(False)
-    timer = None
-    _backup_timer: QTimer | None = None
-    _on_finished: Callable[[], None] | None = None
-
     continue_button = Button("Continue")
     pause_button = TEvent
     pause_label = Property(depends_on="_paused")
     status = Str("idle")
+
     _paused = Bool
-    _continued = Bool
-    _canceled = Bool
     _no_update = False
+    _state: Optional[WaitState] = None
+    _poll_timer: Optional[QTimer] = None
+    _on_finished: Optional[Callable[[], None]] = None
+    _wait_thread: Optional[Thread] = None
 
     def __init__(self, *args: Any, **kw: Any) -> None:
+        super().__init__(*args, **kw)
+        self._state = WaitState(page_name=self.page_name)
         self.reset()
-        super(WaitControl, self).__init__(*args, **kw)
         if self.auto_start:
             self.start(block=False)
 
-    def _get_timer(self) -> QTimer:
-        timer = self.timer
-        if timer is None:
-            app = QApplication.instance()
-            timer = QTimer(app) if app is not None else QTimer()
-            timer.setInterval(1000)
-            timer.timeout.connect(self._update_time)
-            self.timer = timer
-            self.debug(
-                "wait_control timer created page={} timer_id={} app_present={} thread={}".format(
-                    self.page_name,
-                    id(timer),
-                    app is not None,
-                    current_thread().name,
-                )
-            )
-        return timer
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
-    def _start_timer(self) -> None:
-        timer = self._get_timer()
-        self.debug(
-            "wait_control timer starting page={} timer_id={} current_time={} status={} thread={}".format(
-                self.page_name,
-                id(timer),
-                self.current_time,
-                self.status,
-                current_thread().name,
-            )
-        )
-        timer.start()
-
-        # Backup safety net: a Qt single-shot timer (NOT threading.Timer).
-        # threading.Timer fires on a worker thread, and the resulting Qt calls
-        # in _stop_timer/_finish crash on macOS ARM64 due to thread-affinity
-        # enforcement. Keeping the backup as a QTimer ensures _end() runs on
-        # the Qt thread.
-        self._stop_backup_timer()
-        backup_duration_ms = int(max(self.duration + 2.0, 3.0) * 1000)
-        backup = self._get_backup_timer()
-        backup.start(backup_duration_ms)
-        self.debug(
-            "wait_control backup timer started page={} duration_ms={} thread={}".format(
-                self.page_name, backup_duration_ms, current_thread().name
-            )
-        )
-
-    def _get_backup_timer(self) -> QTimer:
-        timer = self._backup_timer
-        if timer is None:
-            app = QApplication.instance()
-            timer = QTimer(app) if app is not None else QTimer()
-            timer.setSingleShot(True)
-            timer.timeout.connect(self._backup_timer_fired)
-            self._backup_timer = timer
-        return timer
-
-    def _stop_backup_timer(self) -> None:
-        timer = self._backup_timer
-        if timer is not None and timer.isActive():
-            timer.stop()
-
-    def _backup_timer_fired(self) -> None:
-        if self._on_finished is not None:
-            self.warning(
-                "wait_control backup timer triggered - Qt timer may be hung page={} status={} current_time={} thread={}".format(
-                    self.page_name,
-                    self.status,
-                    self.current_time,
-                    current_thread().name,
-                )
-            )
-            self._end()
-
-    def _stop_timer(self) -> None:
-        timer = self.timer
-        if timer is not None and timer.isActive():
-            self.debug(
-                "wait_control timer stopping page={} timer_id={} current_time={} status={} thread={}".format(
-                    self.page_name,
-                    id(timer),
-                    self.current_time,
-                    self.status,
-                    current_thread().name,
-                )
-            )
-            timer.stop()
-        self._stop_backup_timer()
-
-    def is_active(self) -> bool:
-        return bool(self.timer and self.timer.isActive())
-
-    def is_canceled(self) -> bool:
-        return self.status in ("canceled", "stopped")
-
-    def is_continued(self) -> bool:
-        return self.status == "continued"
-
-    def set_message(
-        self,
-        message: str,
-        *,
-        color: str | None = None,
-        bgcolor: str | None = None,
-        wait: bool = True,
-    ) -> None:
-        traits: dict[str, Any] = {"message": message}
-        if color is not None:
-            traits["message_color"] = color
-        if bgcolor is not None:
-            traits["message_bgcolor"] = bgcolor
-        self.trait_set(**traits)
-
-    def set_remaining_time(self, remaining: float, *, wait: bool = False) -> None:
-        self.trait_set(current_time=remaining)
-
-    def continue_wait(self) -> None:
-        self._continue()
-
-    def _finish(
-        self,
-        status: str,
-        *,
-        remaining_time: float | None = None,
-        message: str | None = None,
-        color: str | None = None,
-    ) -> None:
-        traits: dict[str, Any] = {
-            "status": status,
-            "_continued": status == "continued",
-            "_canceled": status in ("canceled", "stopped"),
-        }
-        if remaining_time is not None:
-            traits["current_time"] = remaining_time
-        if message is not None:
-            traits["message"] = message
-        if color is not None:
-            traits["message_color"] = color
-
-        self.debug(
-            "wait_control finish page={} from_status={} to_status={} remaining_time={} message={} thread={}".format(
-                self.page_name,
-                self.status,
-                status,
-                remaining_time,
-                message,
-                current_thread().name,
-            )
-        )
-        self.trait_set(**traits)
-
-        self._stop_timer()
-        on_finished = self._on_finished
-        self._on_finished = None
-        if on_finished is not None:
-            on_finished()
+    @property
+    def state(self) -> WaitState:
+        """Direct access to the underlying WaitState (for WaitGroup)."""
+        assert self._state is not None
+        return self._state
 
     def start(
         self,
         block: bool = True,
-        duration: float | None = None,
-        message: str | None = None,
+        duration: Optional[float] = None,
+        message: Optional[str] = None,
         paused: bool = False,
-        on_finished: Callable[[], None] | None = None,
+        on_finished: Optional[Callable[[], None]] = None,
     ) -> None:
+        """Start a wait.
+
+        block=True is no longer supported; callers must use
+        WaitGroup.start_wait or pass on_finished and let the wait run
+        asynchronously. Either is safe from any thread.
+        """
         if block:
             raise RuntimeError(
                 "WaitControl.start(block=True) is no longer supported; "
-                "start waits via WaitGroup.start_wait or a caller-owned completion event"
+                "use WaitGroup.start_wait or pass on_finished"
             )
 
-        self.debug(
-            "wait_control start page={} duration_arg={} message={} paused={} current_time={} status={} thread={}".format(
-                self.page_name,
-                duration,
-                message,
-                paused,
-                self.current_time,
-                self.status,
-                current_thread().name,
-            )
-        )
-        self._on_finished = on_finished
-        self._stop_timer()
-
+        state = self.state
         if duration is not None:
             self.duration = duration
-            self.reset()
+        eff_duration = float(duration) if duration is not None else float(self.duration)
+        eff_message = message if message is not None else self.message
 
-        if message:
-            self.set_message(message)
-
-        self._start_timer()
-        self.trait_set(
-            status="running",
-            _continued=False,
-            _canceled=False,
-            _paused=paused,
-            message_color="black",
-            message_bgcolor="#eaebbc",
-        )
-
-    def stop(self) -> None:
-        status = "stopped" if self.is_active() else "canceled"
         self.debug(
-            "wait_control stop page={} chosen_status={} current_time={} status={} thread={}".format(
+            "wait_control start page={} duration={} message={} paused={} thread={}".format(
                 self.page_name,
-                status,
-                self.current_time,
-                self.status,
+                eff_duration,
+                eff_message,
+                paused,
                 current_thread().name,
             )
         )
-        self._finish(status)
-        self.debug("wait dialog stopped")
+
+        state.page_name = self.page_name
+        state.start(eff_duration, eff_message)
+        if paused:
+            state.request_pause(True)
+
+        # Reset display traits and start polling on the main thread.
+        invoke_in_main_thread(self._begin_view, eff_duration, eff_message, paused)
+
+        # If a callback is requested, run the blocking wait on a helper
+        # thread so this method returns immediately.
+        self._on_finished = on_finished
+        if on_finished is not None:
+            self._wait_thread = Thread(
+                target=self._await_and_callback,
+                name="WaitControl-{}".format(self.page_name),
+                daemon=True,
+            )
+            self._wait_thread.start()
+
+    def stop(self) -> None:
+        """Cancel any running wait. Safe from any thread."""
+        state = self.state
+        outcome_before = state.outcome
+        self.debug(
+            "wait_control stop page={} prior_status={} thread={}".format(
+                self.page_name, outcome_before, current_thread().name
+            )
+        )
+        state.request_cancel()
+        # Synchronously mirror final state into traits so callers that
+        # immediately read .status / .current_time see correct values.
+        self._sync_from_state()
         if self.current_time > 1:
             self.set_message("Stopped", color="red")
+
+    def continue_wait(self) -> None:
+        """Resolve the wait as 'continued'. Safe from any thread."""
+        self.debug(
+            "wait_control continue page={} thread={}".format(
+                self.page_name, current_thread().name
+            )
+        )
+        self.state.request_continue()
+        # Mirror remaining=0 / status="continued" synchronously so callers
+        # don't have to wait for the polling timer to tick.
+        self.current_time = 0
+        self._sync_from_state()
 
     def reset(self) -> None:
         with no_update(self, fire_update_needed=False):
@@ -285,62 +188,132 @@ class WaitControl(Loggable):
                 current_time=self.duration,
                 status="idle",
                 _paused=False,
-                _continued=False,
-                _canceled=False,
             )
 
     def pause(self) -> None:
-        self.trait_set(_paused=True)
+        self.state.request_pause(True)
+        self._paused = True
 
-    # ===============================================================================
-    # private
-    # ===============================================================================
+    def is_active(self) -> bool:
+        return self.state.is_running()
 
-    def _continue(self) -> None:
-        self.debug(
-            "wait_control continue page={} current_time={} status={} thread={}".format(
-                self.page_name, self.current_time, self.status, current_thread().name
-            )
+    def is_canceled(self) -> bool:
+        return self.state.outcome in (CANCELED, "stopped") or self.status in (
+            "canceled",
+            "stopped",
         )
-        self.trait_set(_paused=False)
-        self._finish("continued", remaining_time=0, message="")
 
-    def _end(self) -> None:
-        self.debug(
-            "wait_control end page={} current_time={} status={} thread={}".format(
-                self.page_name, self.current_time, self.status, current_thread().name
-            )
-        )
-        self._finish("completed", remaining_time=0, message="")
+    def is_continued(self) -> bool:
+        return self.state.outcome == CONTINUED
 
-    def _update_time(self) -> None:
-        if self._paused:
-            self.debug(
-                "wait_control tick skipped page={} current_time={} status={} paused={} thread={}".format(
-                    self.page_name,
-                    self.current_time,
-                    self.status,
-                    self._paused,
-                    current_thread().name,
-                )
+    def set_message(
+        self,
+        message: str,
+        *,
+        color: Optional[str] = None,
+        bgcolor: Optional[str] = None,
+        wait: bool = True,
+    ) -> None:
+        traits: dict[str, Any] = {"message": message}
+        if color is not None:
+            traits["message_color"] = color
+        if bgcolor is not None:
+            traits["message_bgcolor"] = bgcolor
+        self.trait_set(**traits)
+        self.state.set_message(message)
+
+    def set_remaining_time(self, remaining: float, *, wait: bool = False) -> None:
+        self.state.set_remaining(remaining)
+        self.trait_set(current_time=remaining)
+
+    # ------------------------------------------------------------------
+    # Polling timer (mirrors WaitState into display traits)
+    # ------------------------------------------------------------------
+
+    def _begin_view(self, duration: float, message: str, paused: bool) -> None:
+        """Reset display traits and start polling. Main thread only.
+
+        Called via invoke_in_main_thread; safe even if the main thread is
+        slow because state.wait() does not depend on this completing.
+        """
+        with no_update(self, fire_update_needed=False):
+            self.trait_set(
+                high=int(duration),
+                current_time=duration,
+                status="running",
+                _paused=paused,
+                message=message,
+                message_color="black",
+                message_bgcolor="#eaebbc",
             )
-            return
-        if not self.is_active():
-            return
-        ct = self.current_time - 1
-        self.debug(
-            "wait_control tick page={} next_time={} current_time={} status={} thread={}".format(
-                self.page_name,
-                ct,
-                self.current_time,
-                self.status,
-                current_thread().name,
-            )
-        )
-        if ct <= 0:
-            self._end()
-        else:
-            self.set_remaining_time(ct)
+        self._ensure_polling()
+
+    def _ensure_polling(self) -> None:
+        """Create (if needed) and start the polling QTimer. Main thread only."""
+        timer = self._poll_timer
+        if timer is None:
+            app = QApplication.instance()
+            timer = QTimer(app) if app is not None else QTimer()
+            timer.setInterval(_POLL_INTERVAL_MS)
+            timer.timeout.connect(self._poll)
+            self._poll_timer = timer
+        if not timer.isActive():
+            timer.start()
+
+    def _stop_polling(self) -> None:
+        timer = self._poll_timer
+        if timer is not None and timer.isActive():
+            timer.stop()
+
+    def _poll(self) -> None:
+        """Tick: read snapshot, update display traits, stop when resolved."""
+        snap = self.state.snapshot()
+        self._sync_from_snapshot(snap)
+        if snap.outcome != RUNNING:
+            self._stop_polling()
+
+    def _sync_from_state(self) -> None:
+        self._sync_from_snapshot(self.state.snapshot())
+
+    def _sync_from_snapshot(self, snap: WaitSnapshot) -> None:
+        # Map state outcomes back to legacy status strings for any callers
+        # that still inspect .status directly.
+        status_map = {
+            IDLE: "idle",
+            RUNNING: "running",
+            COMPLETED: "completed",
+            CONTINUED: "continued",
+            CANCELED: "canceled",
+        }
+        traits: dict[str, Any] = {
+            "current_time": snap.remaining,
+            "_paused": snap.paused,
+            "status": status_map.get(snap.outcome, snap.outcome),
+        }
+        if snap.message != self.message:
+            traits["message"] = snap.message
+        with no_update(self, fire_update_needed=False):
+            self.trait_set(**traits)
+
+    # ------------------------------------------------------------------
+    # Background helpers
+    # ------------------------------------------------------------------
+
+    def _await_and_callback(self) -> None:
+        try:
+            self.state.wait()
+        finally:
+            cb = self._on_finished
+            self._on_finished = None
+            if cb is not None:
+                try:
+                    cb()
+                except Exception:
+                    self.debug("on_finished callback raised", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Display helpers / button handlers
+    # ------------------------------------------------------------------
 
     def _get_current_display_time(self) -> str:
         return "{:03d}".format(int(self.current_time))
@@ -348,11 +321,10 @@ class WaitControl(Loggable):
     def _get_pause_label(self) -> str:
         return "Unpause" if self._paused else "Pause"
 
-    # ===============================================================================
-    # handlers
-    # ===============================================================================
     def _pause_button_fired(self) -> None:
-        self.trait_set(_paused=not self._paused)
+        new = not self._paused
+        self.state.request_pause(new)
+        self._paused = new
 
     def _continue_button_fired(self) -> None:
         self.continue_wait()
@@ -360,7 +332,6 @@ class WaitControl(Loggable):
     def _high_changed(self, v: int) -> None:
         if self._no_update:
             return
-
         self.duration = v
         self.set_remaining_time(v)
 

--- a/pychron/core/wait/wait_group.py
+++ b/pychron/core/wait/wait_group.py
@@ -15,6 +15,9 @@
 # ===============================================================================
 
 # ============= enthought library imports =======================
+import faulthandler
+import os
+import time
 from threading import Event, current_thread, main_thread
 from typing import Any as TypingAny, Callable, Optional
 
@@ -24,6 +27,36 @@ from traits.api import HasTraits, List, Any, Property
 # ============= local library imports  ==========================
 from pychron.core.ui.gui import invoke_in_main_thread
 from pychron.core.wait.wait_control import WaitControl
+
+
+def _dump_all_thread_tracebacks(page_name: str, logger: TypingAny) -> None:
+    """Dump tracebacks for all threads to a file in the log dir.
+
+    Used to diagnose hangs when the WaitGroup safety timeout fires - the
+    main thread is presumably blocked on something, and this captures what.
+    """
+    try:
+        from pychron.paths import paths
+
+        log_dir = getattr(paths, "log_dir", None)
+        if not log_dir or not os.path.isdir(log_dir):
+            logger.warning(
+                "wait_group cannot dump tracebacks: log_dir not available"
+            )
+            return
+
+        ts = time.strftime("%Y%m%d_%H%M%S")
+        safe_page = "".join(c if c.isalnum() else "_" for c in page_name)[:40]
+        path = os.path.join(log_dir, "wait_hang_{}_{}.txt".format(ts, safe_page))
+        with open(path, "w") as fh:
+            fh.write(
+                "WaitGroup safety timeout traceback dump\n"
+                "page={} timestamp={}\n\n".format(page_name, ts)
+            )
+            faulthandler.dump_traceback(file=fh, all_threads=True)
+        logger.warning("wait_group thread traceback dumped to {}".format(path))
+    except Exception as e:
+        logger.warning("wait_group failed to dump tracebacks: {}".format(e))
 
 
 class WaitGroup(HasTraits):
@@ -197,6 +230,10 @@ class WaitGroup(HasTraits):
                         current_thread().name,
                     )
                 )
+                # Diagnostic: dump all thread tracebacks so we can see what the
+                # main thread was busy with. Done from this (experiment) thread
+                # so it works even when the main thread is fully blocked.
+                _dump_all_thread_tracebacks(control.page_name, control)
                 # Force completion - use wait=False because the main thread may
                 # still be blocked; we must not deadlock the experiment thread here.
                 self._invoke_on_main_thread(control._end, wait=False)

--- a/pychron/core/wait/wait_group.py
+++ b/pychron/core/wait/wait_group.py
@@ -197,8 +197,9 @@ class WaitGroup(HasTraits):
                         current_thread().name,
                     )
                 )
-                # Force completion to prevent indefinite hang
-                self._invoke_on_main_thread(control._end, wait=True)
+                # Force completion - use wait=False because the main thread may
+                # still be blocked; we must not deadlock the experiment thread here.
+                self._invoke_on_main_thread(control._end, wait=False)
             
             control.debug(
                 "wait_group wait complete page={} status={} current_time={} timeout={} thread={}".format(

--- a/pychron/core/wait/wait_group.py
+++ b/pychron/core/wait/wait_group.py
@@ -13,50 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===============================================================================
+"""WaitGroup: collection of WaitControls plus a blocking wait coordinator.
+
+After the 2026 rewrite, blocking is implemented directly on top of
+WaitState (pure threading). The Qt event loop is not on the critical
+path, so safety timeouts, faulthandler dumps, and synchronous
+cross-thread calls (`wait=True`) are no longer needed.
+"""
 
 # ============= enthought library imports =======================
-import faulthandler
-import os
-import time
 from threading import Event, current_thread, main_thread
 from typing import Any as TypingAny, Callable, Optional
 
-from traits.api import HasTraits, List, Any, Property
+from traits.api import Any, HasTraits, List, Property
 
-# ============= standard library imports ========================
 # ============= local library imports  ==========================
 from pychron.core.ui.gui import invoke_in_main_thread
 from pychron.core.wait.wait_control import WaitControl
-
-
-def _dump_all_thread_tracebacks(page_name: str, logger: TypingAny) -> None:
-    """Dump tracebacks for all threads to a file in the log dir.
-
-    Used to diagnose hangs when the WaitGroup safety timeout fires - the
-    main thread is presumably blocked on something, and this captures what.
-    """
-    try:
-        from pychron.paths import paths
-
-        log_dir = getattr(paths, "log_dir", None)
-        if not log_dir or not os.path.isdir(log_dir):
-            logger.warning(
-                "wait_group cannot dump tracebacks: log_dir not available"
-            )
-            return
-
-        ts = time.strftime("%Y%m%d_%H%M%S")
-        safe_page = "".join(c if c.isalnum() else "_" for c in page_name)[:40]
-        path = os.path.join(log_dir, "wait_hang_{}_{}.txt".format(ts, safe_page))
-        with open(path, "w") as fh:
-            fh.write(
-                "WaitGroup safety timeout traceback dump\n"
-                "page={} timestamp={}\n\n".format(page_name, ts)
-            )
-            faulthandler.dump_traceback(file=fh, all_threads=True)
-        logger.warning("wait_group thread traceback dumped to {}".format(path))
-    except Exception as e:
-        logger.warning("wait_group failed to dump tracebacks: {}".format(e))
 
 
 class WaitGroup(HasTraits):
@@ -67,33 +40,31 @@ class WaitGroup(HasTraits):
     def _get_single(self) -> bool:
         return len(self.controls) == 1
 
-    # def traits_view(self):
-    #     v = View(UItem('active_control',
-    #                    style='custom',
-    #                    visible_when='single',
-    #                    editor=InstanceEditor()),
-    #              UItem('controls',
-    #                    editor=ListEditor(
-    #                        use_notebook=True,
-    #                        selected='active_control',
-    #                        page_name='.page_name'),
-    #                    style='custom',
-    #                    visible_when='not single'))
-    #     return v
-
     def _controls_default(self) -> list[WaitControl]:
         return [WaitControl()]
 
     def _active_control_default(self) -> WaitControl:
         return self.controls[0]
 
+    # ------------------------------------------------------------------
+    # Cross-thread helper
+    # ------------------------------------------------------------------
+
     def _invoke_on_main_thread(
         self,
         func: Callable[..., TypingAny],
         *args: TypingAny,
         wait: bool = False,
-        **kw: TypingAny
+        **kw: TypingAny,
     ) -> Optional[TypingAny]:
+        """Run `func` on the main thread.
+
+        With `wait=False` (default), fire-and-forget. With `wait=True`,
+        block until `func` returns. Synchronous waits are still used for
+        UI-only operations (e.g. swapping the active page in a notebook)
+        where the caller needs the result; they are NEVER used inside the
+        blocking wait path, so they cannot deadlock the experiment thread.
+        """
         if current_thread() is main_thread():
             return func(*args, **kw)
 
@@ -114,6 +85,10 @@ class WaitGroup(HasTraits):
         done.wait()
         return result.get("value")
 
+    # ------------------------------------------------------------------
+    # Control management (UI-side, synchronous helpers OK here)
+    # ------------------------------------------------------------------
+
     def pop(self, control: Optional[WaitControl] = None) -> None:
         self._invoke_on_main_thread(self._pop, control, wait=True)
 
@@ -124,7 +99,6 @@ class WaitGroup(HasTraits):
                     self.controls.remove(control)
             else:
                 self.controls.pop()
-
             self.active_control = self.controls[-1]
 
     def stop(self) -> None:
@@ -166,6 +140,10 @@ class WaitGroup(HasTraits):
             control = self.add_control(**kw)
         return control
 
+    # ------------------------------------------------------------------
+    # The blocking wait — pure threading, no Qt dependency
+    # ------------------------------------------------------------------
+
     def start_wait(
         self,
         control: WaitControl,
@@ -174,79 +152,59 @@ class WaitGroup(HasTraits):
         message: str | None = None,
         paused: bool = False,
         block: bool = True,
-    ) -> None:
-        done = Event()
-        timeout_occurred = False
+    ) -> str | None:
+        """Begin a wait on `control`.
 
-        def on_finished() -> None:
-            control.debug(
-                "wait_group on_finished page={} status={} current_time={} thread={}".format(
-                    control.page_name,
-                    control.status,
-                    control.current_time,
-                    current_thread().name,
-                )
-            )
-            done.set()
+        Returns the final outcome (`"completed"`, `"continued"`, or
+        `"canceled"`) when block=True; returns None when block=False.
+
+        The blocking wait runs on the calling thread via WaitState.wait(),
+        which uses a threading.Event with timeout. The Qt event loop is
+        not required for progress: a starved main thread will only delay
+        the on-screen countdown, never the experiment.
+        """
+        state = control.state
+        eff_duration = float(duration) if duration is not None else float(control.duration)
 
         control.debug(
-            "wait_group start_wait page={} duration={} message={} paused={} block={} active_control={} controls={} thread={}".format(
+            "wait_group start_wait page={} duration={} message={} paused={} block={} thread={}".format(
                 control.page_name,
-                duration,
+                eff_duration,
                 message,
                 paused,
                 block,
-                getattr(self.active_control, "page_name", None),
-                len(self.controls),
                 current_thread().name,
             )
         )
-        self._invoke_on_main_thread(
-            control.start,
-            block=False,
-            duration=duration,
-            message=message,
-            paused=paused,
-            on_finished=on_finished,
-            wait=True,
+
+        # Start state on this (experiment) thread so timing begins
+        # immediately and is independent of Qt event-loop responsiveness.
+        eff_message = message if message is not None else control.message
+        state.page_name = control.page_name
+        state.start(eff_duration, eff_message)
+        if paused:
+            state.request_pause(True)
+
+        # Reset display traits and start polling on the main thread.
+        # Fire-and-forget: even if the main thread is busy, the wait
+        # below proceeds independently.
+        invoke_in_main_thread(
+            control._begin_view, eff_duration, eff_message, paused
         )
 
-        if block:
-            control.debug(
-                "wait_group waiting page={} thread={}".format(
-                    control.page_name, current_thread().name
-                )
+        if not block:
+            return None
+
+        outcome = state.wait()
+        control.debug(
+            "wait_group wait complete page={} outcome={} thread={}".format(
+                control.page_name, outcome, current_thread().name
             )
-            # Add safety timeout to prevent indefinite hangs if Qt timer never fires
-            # Timeout is duration + 5 seconds (buffer for event loop processing)
-            safety_timeout = (duration or 10) + 5.0
-            if not done.wait(timeout=safety_timeout):
-                timeout_occurred = True
-                control.warning(
-                    "wait_group safety timeout triggered page={} duration={} timeout={} thread={}".format(
-                        control.page_name,
-                        duration,
-                        safety_timeout,
-                        current_thread().name,
-                    )
-                )
-                # Diagnostic: dump all thread tracebacks so we can see what the
-                # main thread was busy with. Done from this (experiment) thread
-                # so it works even when the main thread is fully blocked.
-                _dump_all_thread_tracebacks(control.page_name, control)
-                # Force completion - use wait=False because the main thread may
-                # still be blocked; we must not deadlock the experiment thread here.
-                self._invoke_on_main_thread(control._end, wait=False)
-            
-            control.debug(
-                "wait_group wait complete page={} status={} current_time={} timeout={} thread={}".format(
-                    control.page_name,
-                    control.status,
-                    control.current_time,
-                    timeout_occurred,
-                    current_thread().name,
-                )
-            )
+        )
+        # Make sure the UI converges to the final state even if the polling
+        # timer didn't get a chance to run after resolution.
+        invoke_in_main_thread(control._sync_from_state)
+        return outcome
 
 
 # ============= EOF =============================================

--- a/pychron/core/wait/wait_state.py
+++ b/pychron/core/wait/wait_state.py
@@ -124,14 +124,18 @@ class WaitState:
             )
 
     def request_continue(self) -> None:
+        """Resolve as CONTINUED. No-op if already resolved (COMPLETED,
+        CONTINUED, or CANCELED). Allowed from IDLE so callers can
+        preemptively answer before a wait even starts."""
         with self._lock:
-            if self._outcome == RUNNING:
+            if self._outcome in (IDLE, RUNNING):
                 self._outcome = CONTINUED
         self._interrupt.set()
 
     def request_cancel(self) -> None:
+        """Resolve as CANCELED. Same precedence rules as request_continue."""
         with self._lock:
-            if self._outcome == RUNNING:
+            if self._outcome in (IDLE, RUNNING):
                 self._outcome = CANCELED
         self._interrupt.set()
 

--- a/pychron/core/wait/wait_state.py
+++ b/pychron/core/wait/wait_state.py
@@ -1,0 +1,186 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# ===============================================================================
+"""Thread-safe wait state.
+
+The truth for one wait: how long, how much is left, whether the user has
+asked to continue/cancel/pause. Owned by the experiment thread; the UI
+reads snapshots and posts requests but never blocks experiment progress.
+
+Deliberately has no Qt or Traits dependency. Timing correctness must not
+depend on the GUI event loop being responsive.
+"""
+import time
+from dataclasses import dataclass, field
+from threading import Event, Lock
+from typing import Optional
+
+
+# Outcome values
+IDLE = "idle"
+RUNNING = "running"
+COMPLETED = "completed"   # deadline reached
+CONTINUED = "continued"   # user clicked Continue
+CANCELED = "canceled"     # programmatic stop or user cancel
+
+
+@dataclass(frozen=True)
+class WaitSnapshot:
+    """Immutable view of WaitState for the UI to render."""
+    page_name: str
+    remaining: float
+    duration: float
+    message: str
+    paused: bool
+    outcome: str
+
+
+class WaitState:
+    """Thread-safe state for a single wait.
+
+    The experiment thread calls `start()` then blocks on `wait()`.
+    The UI calls `snapshot()` to repaint and `request_*()` to act on
+    button clicks. All cross-thread coordination is via a Lock + Event.
+    """
+
+    def __init__(self, page_name: str = "Wait") -> None:
+        self.page_name = page_name
+        self._lock = Lock()
+        self._interrupt = Event()
+
+        # All fields below are guarded by _lock.
+        self._duration: float = 0.0
+        self._deadline: float = 0.0       # monotonic time
+        self._paused_at: Optional[float] = None
+        self._message: str = ""
+        self._outcome: str = IDLE
+
+    # ------------------------------------------------------------------
+    # Experiment-thread API
+    # ------------------------------------------------------------------
+
+    def start(self, duration: float, message: str = "") -> None:
+        """Begin a new wait. Resets any prior state."""
+        now = time.monotonic()
+        with self._lock:
+            self._duration = float(duration)
+            self._deadline = now + float(duration)
+            self._paused_at = None
+            self._message = message
+            self._outcome = RUNNING
+            self._interrupt.clear()
+
+    def wait(self) -> str:
+        """Block the calling thread until the wait resolves.
+
+        Returns the final outcome (COMPLETED, CONTINUED, or CANCELED).
+        Wakes early on continue/cancel/pause/resume via the interrupt event.
+        """
+        while True:
+            with self._lock:
+                outcome = self._outcome
+                if outcome != RUNNING:
+                    return outcome
+                if self._paused_at is not None:
+                    timeout: Optional[float] = None
+                else:
+                    timeout = self._deadline - time.monotonic()
+                    if timeout <= 0:
+                        self._outcome = COMPLETED
+                        return COMPLETED
+
+            # Released the lock — block until interrupted or timeout.
+            self._interrupt.wait(timeout=timeout)
+            self._interrupt.clear()
+
+    # ------------------------------------------------------------------
+    # UI-thread API (non-blocking)
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> WaitSnapshot:
+        """Cheap read of current state. Safe from any thread."""
+        with self._lock:
+            if self._outcome == IDLE:
+                remaining = self._duration
+            elif self._paused_at is not None:
+                remaining = max(0.0, self._deadline - self._paused_at)
+            elif self._outcome == RUNNING:
+                remaining = max(0.0, self._deadline - time.monotonic())
+            else:
+                remaining = 0.0
+            return WaitSnapshot(
+                page_name=self.page_name,
+                remaining=remaining,
+                duration=self._duration,
+                message=self._message,
+                paused=self._paused_at is not None,
+                outcome=self._outcome,
+            )
+
+    def request_continue(self) -> None:
+        with self._lock:
+            if self._outcome == RUNNING:
+                self._outcome = CONTINUED
+        self._interrupt.set()
+
+    def request_cancel(self) -> None:
+        with self._lock:
+            if self._outcome == RUNNING:
+                self._outcome = CANCELED
+        self._interrupt.set()
+
+    def request_pause(self, paused: bool) -> None:
+        """Pause or resume the countdown. Pausing freezes remaining time;
+        resuming extends the deadline by the pause duration."""
+        with self._lock:
+            now = time.monotonic()
+            if paused and self._paused_at is None:
+                self._paused_at = now
+            elif not paused and self._paused_at is not None:
+                self._deadline += now - self._paused_at
+                self._paused_at = None
+        self._interrupt.set()
+
+    def set_message(self, message: str) -> None:
+        with self._lock:
+            self._message = message
+
+    def set_remaining(self, remaining: float) -> None:
+        """Adjust the deadline so `remaining` seconds are left from now.
+
+        Used by callers that want to extend or shorten an in-flight wait
+        (e.g. countdown displays driven from outside)."""
+        now = time.monotonic()
+        with self._lock:
+            self._deadline = now + float(remaining)
+            if self._paused_at is not None:
+                # Keep paused; reframe so resume gives `remaining` left.
+                self._paused_at = now
+        self._interrupt.set()
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def outcome(self) -> str:
+        with self._lock:
+            return self._outcome
+
+    def is_running(self) -> bool:
+        return self.outcome == RUNNING
+
+    def is_canceled(self) -> bool:
+        return self.outcome == CANCELED
+
+    def is_continued(self) -> bool:
+        return self.outcome == CONTINUED
+
+
+# ============= EOF =============================================


### PR DESCRIPTION
## Summary

Fixes a class of bugs where an experiment can hang indefinitely between
runs because the WaitControl countdown depends on the Qt event loop
firing a QTimer. When the main thread gets busy (e.g. processing a flood
of trait notifications after a long run), the timer never fires, the
wait never resolves, and the experiment thread is stuck.

The triggering incident: an experiment on the M3 hung after run 49 of
MassSpecBlanks. The 5-second "delay between runs" wait never returned
and the run sequence stopped.

## What changed

The PR is structured as four commits, each independently useful:

1. **Hot fix (`6fcfff4e2`)** — the safety-timeout recovery path in
   `WaitGroup.start_wait` was itself deadlocking on
   `_invoke_on_main_thread(control._end, wait=True)`. Switched to
   `wait=False` so the experiment thread can never get permanently stuck
   even if the existing architecture is kept.
2. **Diagnostic (`7fefa0ad6`)** — when the safety timeout fires, write
   `faulthandler.dump_traceback(all_threads=True)` to
   `{log_dir}/wait_hang_{ts}_{page}.txt` so the next hang gives us a
   stack trace for every thread (driven from the experiment thread so it
   works even when the main thread is fully blocked).
3. **New timing core (`e888bc24d`)** — `WaitState` (in `wait_state.py`):
   pure-Python, thread-safe, no Qt and no Traits. Uses
   `threading.Event.wait(timeout=...)` for the actual wait. 14 unit
   tests cover deadline accuracy, continue/cancel interrupt latency,
   pause+resume deadline extension, snapshot stability while paused,
   late-button-press idempotence, and concurrent-button-press race
   resolution.
4. **Architectural rewrite (`656dde693`)** — `WaitControl` becomes a
   TraitsUI façade over `WaitState` plus a 100 ms polling QTimer that
   mirrors snapshots into display traits. `WaitGroup.start_wait` now
   blocks directly on `state.wait()`. The Qt event loop is no longer on
   the critical path; the safety timeout, faulthandler dump, and
   recovery path are removed because the hang class is now structurally
   impossible. 4 new integration tests in `test_wait_group.py` prove
   this by running with no QApplication.

## Why this matters

Before: timing correctness depended on UI responsiveness. A starved
main thread could delay or hang an experiment.

After: a busy main thread can only freeze the on-screen countdown
display briefly. The experiment thread does pure
`threading.Event.wait(timeout=remaining)` and is independent of Qt.

## Trait surface preserved

`WaitControl` still exposes `current_time`, `duration`, `high`,
`message`, `message_color`, `continue_button`, `pause_button`,
`pause_label`, `status` — every trait used in `laser_panes.py`,
`pulse.py`, etc. Existing TraitsUI bindings are unchanged. The
`pulse.py`-style `start(block=False, on_finished=callback)` API is
also preserved (the façade spawns a helper thread that blocks on
`state.wait()` and fires the callback).

## Test plan

- [x] `python -m unittest pychron.core.wait.tests.test_wait_state` — 14 tests, all pass
- [x] `python -m unittest pychron.core.wait.tests.test_wait_control` — 3 legacy tests still pass against the new façade
- [x] `python -m unittest pychron.core.wait.tests.test_wait_group` — 4 new integration tests pass with no QApplication
- [ ] Run a full experiment on the M3 to confirm the rewrite holds up under the workload that triggered the original hang
- [ ] Spot-check that the WaitControl panel in `laser_panes.py` and `pulse.py` still updates the countdown display correctly during a wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)