### PR TITLE
feat: per-runid log folders + skip DB persistence in sim mode

### DIFF
--- a/pychron/dvc/dvc_persister.py
+++ b/pychron/dvc/dvc_persister.py
@@ -47,6 +47,7 @@ from pychron.experiment.automated_run.persistence import BasePersister
 from pychron.experiment.automated_run.persistence_spec import PersistenceSpec
 from pychron.experiment.automated_run.spec import AutomatedRunSpec
 from pychron.git_archive.repo_manager import GitRepoManager
+from pychron.globals import globalv
 from pychron.paths import paths
 from pychron.pychron_constants import (
     DVC_PROTOCOL,
@@ -289,6 +290,15 @@ class DVCPersister(BasePersister):
 
         :return:
         """
+        if globalv.communication_simulation:
+            self.warning(
+                "simulation mode active (communication_simulation=True): "
+                "skipping post_measurement_save to avoid polluting DVC repo with simulated data"
+            )
+            if complete_event:
+                complete_event.clear()
+            return
+
         self.info("================= post measurement save started =================")
 
         self._timings = {}
@@ -463,6 +473,12 @@ class DVCPersister(BasePersister):
         self._dump_timings()
 
     def save_run_log_file(self, path):
+        if globalv.communication_simulation:
+            self.warning(
+                "simulation mode active (communication_simulation=True): "
+                "skipping save_run_log_file to avoid polluting DVC repo with simulated data"
+            )
+            return
         if self.save_enabled and self.save_log_enabled:
             self.debug("saving run log file")
 

--- a/pychron/experiment/experiment_executor.py
+++ b/pychron/experiment/experiment_executor.py
@@ -1601,7 +1601,10 @@ class ExperimentExecutor(Consoleable, PreferenceMixin):
         # add a new log handler
 
         name = run.runid.replace(":", "_")
-        p, _ = unique_path2(paths.log_dir, name, extension=".log")
+        run_log_dir = os.path.join(paths.automated_run_log_dir, name)
+        if not os.path.isdir(run_log_dir):
+            os.makedirs(run_log_dir)
+        p, _ = unique_path2(run_log_dir, name, extension=".log")
         handler = add_root_handler(p)
         run.log_path = p
 

--- a/pychron/labspy/client.py
+++ b/pychron/labspy/client.py
@@ -26,6 +26,7 @@ from traits.api import Instance, Bool, Int
 
 from pychron.core.helpers.logger_setup import logging_setup
 from pychron.core.yaml import yload
+from pychron.globals import globalv
 from pychron.hardware.core.i_core_device import ICoreDevice
 from pychron.labspy.database_adapter import LabspyDatabaseAdapter
 from pychron.loggable import Loggable
@@ -244,6 +245,12 @@ class LabspyClient(Loggable):
 
     @auto_reset_connect
     def add_run(self, run, exp):
+        if globalv.communication_simulation:
+            self.warning(
+                "simulation mode active (communication_simulation=True): "
+                "skipping Labspy add_run to avoid polluting DB with simulated data"
+            )
+            return
         hid = self._generate_hid_from_exp(exp)
         expid = self.db.get_experiment(hid)
         if not expid:

--- a/pychron/paths.py
+++ b/pychron/paths.py
@@ -136,6 +136,7 @@ class Paths(object):
     test_dir = None
     custom_queries_dir = None
     log_dir = None
+    automated_run_log_dir = None
     peak_center_config_dir = None
     # ===========================================================================
     # scripts
@@ -342,6 +343,7 @@ class Paths(object):
         root = os.path.normpath(root)
         self.root_dir = root
         self.log_dir = join(root, "logs")
+        self.automated_run_log_dir = join(self.log_dir, "automated_runs")
 
         # ==============================================================================
         # root


### PR DESCRIPTION
## Summary

Two related fixes around automated-run logging and simulation-mode safety.

### 1. Per-runid log folders ([31ea735aa](../commit/31ea735aa))

Automated run logs now land in `logs/automated_runs/<runid>/<runid>.log` instead of a flat `logs/<runid>.log`. Adds a new `paths.automated_run_log_dir` constant, auto-created via `build_directories()` and on demand per run.

Files: `pychron/paths.py`, `pychron/experiment/experiment_executor.py`

### 2. Skip DB persistence when `communication_simulation=True` ([435ac27f9](../commit/435ac27f9))

Before this change, running pychron with `<communication_simulation>True</communication_simulation>` in `initialization.xml` would still write simulated detector intensities (e.g. the hardcoded `[1, 100, 3, 0.01, ...]` from `BaseSpectrometer._get_simulation_data`) to the DVC repo and Labspy MySQL, indistinguishable from real measurements. That polluted production data stores during testing.

Early-return guards added on:
- `DVCPersister.post_measurement_save` — clears `complete_event` so the caller does not deadlock waiting on the save
- `DVCPersister.save_run_log_file`
- `LabspyClient.add_run`

Each guard logs a `WARNING` explaining the skip. Real-mode behavior is unchanged. Per-run log files are still written locally; only the DVC push step is skipped.

Files: `pychron/dvc/dvc_persister.py`, `pychron/labspy/client.py`

## Reviewer notes

- Other persisters (mass_spec writer, xls writer, etc.) still have no sim guard. Touch them in a follow-up if needed.
- The `complete_event.clear()` in the guarded `post_measurement_save` mirrors the existing clear at the end of the function so the executor does not block on the save thread.

## Test plan

- [ ] Run an experiment in sim mode (`communication_simulation=True`) and confirm:
  - [ ] No new commits in the active DVC repo
  - [ ] No new rows in Labspy MySQL
  - [ ] Local run log still appears at `~/Pychron/logs/automated_runs/<runid>/<runid>.log`
  - [ ] WARNING lines like `simulation mode active ... skipping post_measurement_save` show in `pychron.current.log`
- [ ] Run an experiment in real mode and confirm DVC commits + Labspy inserts still happen as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)