### PR TITLE
Revert PR #2322 (sanity bisect: pychron failed to start)

### DIFF
--- a/pychron/dvc/dvc_persister.py
+++ b/pychron/dvc/dvc_persister.py
@@ -47,7 +47,6 @@ from pychron.experiment.automated_run.persistence import BasePersister
 from pychron.experiment.automated_run.persistence_spec import PersistenceSpec
 from pychron.experiment.automated_run.spec import AutomatedRunSpec
 from pychron.git_archive.repo_manager import GitRepoManager
-from pychron.globals import globalv
 from pychron.paths import paths
 from pychron.pychron_constants import (
     DVC_PROTOCOL,
@@ -290,15 +289,6 @@ class DVCPersister(BasePersister):
 
         :return:
         """
-        if globalv.communication_simulation:
-            self.warning(
-                "simulation mode active (communication_simulation=True): "
-                "skipping post_measurement_save to avoid polluting DVC repo with simulated data"
-            )
-            if complete_event:
-                complete_event.clear()
-            return
-
         self.info("================= post measurement save started =================")
 
         self._timings = {}
@@ -473,12 +463,6 @@ class DVCPersister(BasePersister):
         self._dump_timings()
 
     def save_run_log_file(self, path):
-        if globalv.communication_simulation:
-            self.warning(
-                "simulation mode active (communication_simulation=True): "
-                "skipping save_run_log_file to avoid polluting DVC repo with simulated data"
-            )
-            return
         if self.save_enabled and self.save_log_enabled:
             self.debug("saving run log file")
 

--- a/pychron/experiment/experiment_executor.py
+++ b/pychron/experiment/experiment_executor.py
@@ -1601,10 +1601,7 @@ class ExperimentExecutor(Consoleable, PreferenceMixin):
         # add a new log handler
 
         name = run.runid.replace(":", "_")
-        run_log_dir = os.path.join(paths.automated_run_log_dir, name)
-        if not os.path.isdir(run_log_dir):
-            os.makedirs(run_log_dir)
-        p, _ = unique_path2(run_log_dir, name, extension=".log")
+        p, _ = unique_path2(paths.log_dir, name, extension=".log")
         handler = add_root_handler(p)
         run.log_path = p
 

--- a/pychron/labspy/client.py
+++ b/pychron/labspy/client.py
@@ -26,7 +26,6 @@ from traits.api import Instance, Bool, Int
 
 from pychron.core.helpers.logger_setup import logging_setup
 from pychron.core.yaml import yload
-from pychron.globals import globalv
 from pychron.hardware.core.i_core_device import ICoreDevice
 from pychron.labspy.database_adapter import LabspyDatabaseAdapter
 from pychron.loggable import Loggable
@@ -245,12 +244,6 @@ class LabspyClient(Loggable):
 
     @auto_reset_connect
     def add_run(self, run, exp):
-        if globalv.communication_simulation:
-            self.warning(
-                "simulation mode active (communication_simulation=True): "
-                "skipping Labspy add_run to avoid polluting DB with simulated data"
-            )
-            return
         hid = self._generate_hid_from_exp(exp)
         expid = self.db.get_experiment(hid)
         if not expid:

--- a/pychron/paths.py
+++ b/pychron/paths.py
@@ -136,7 +136,6 @@ class Paths(object):
     test_dir = None
     custom_queries_dir = None
     log_dir = None
-    automated_run_log_dir = None
     peak_center_config_dir = None
     # ===========================================================================
     # scripts
@@ -343,7 +342,6 @@ class Paths(object):
         root = os.path.normpath(root)
         self.root_dir = root
         self.log_dir = join(root, "logs")
-        self.automated_run_log_dir = join(self.log_dir, "automated_runs")
 
         # ==============================================================================
         # root


### PR DESCRIPTION
Reverts PR #2322 to bisect a pychron startup failure reported after merging. PR #2322 changed:

- `pychron/paths.py` — added `automated_run_log_dir`
- `pychron/experiment/experiment_executor.py` — per-runid log subdir
- `pychron/dvc/dvc_persister.py` — sim-mode guards
- `pychron/labspy/client.py` — sim-mode guards

After merging PR #2322, pychron failed to start (no new `pychron.current.log` created, no Python crash dump).

Reverting first to confirm root cause. If pychron starts cleanly after this revert, the four files above are the source. The sim-guards are unlikely culprits (only execute inside per-run save methods, not at startup), so the next step is to re-apply just the sim-guard commit on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)