### PR TITLE
fix(dvc): self-heal interrupted MERGE_HEAD on stale staged content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ notes
 alembic.ini
 update_alembic.ini
 /pychron/hddocs.md
+
+# Local working copies / backups (Felix -> Jan transition + ad-hoc backups)
+*.bak
+.claude/
+launchers-Felix/
+launchers/helpers-Jan.py
+pychron/extraction_line/switch_manager-Jan.py

--- a/M3_INSTRUMENTATION.md
+++ b/M3_INSTRUMENTATION.md
@@ -1,0 +1,223 @@
+# M3 ARM64 Segmentation Fault Instrumentation Guide
+
+## Overview
+This document describes the instrumentation added to help diagnose and prevent M3 segmentation faults caused by cross-thread Qt access.
+
+## Quick Start
+
+### Enable Thread Safety Checks at Startup
+```python
+from pychron.core.ui.gui import enable_thread_safety_checks
+
+# Enable detailed thread safety monitoring
+enable_thread_safety_checks(True)
+```
+
+### In Your Application's Initialization
+```python
+# pychron/applications/pychron.py or your main application file
+def bootstrap(self):
+    # ... existing code ...
+    
+    # Enable thread safety checks (especially useful on M3/ARM64)
+    from pychron.core.ui.gui import enable_thread_safety_checks
+    import sys
+    
+    # Check if running on M3
+    is_m3 = 'arm64' in sys.platform.lower()
+    enable_thread_safety_checks(is_m3)
+```
+
+## What Gets Instrumented
+
+### 1. **invoke_in_main_thread() Function**
+- Logs when operations are deferred to main thread
+- Tracks source thread that queued the operation
+- Warns if main thread is blocked >1s before executing
+
+**Output in logs:**
+```
+[ThreadSafety] DEBUG: Deferred to main thread: _update_plot_panel_counts from WaitControl(id=123456789)
+[ThreadSafety] DEBUG: Executing deferred: _update_plot_panel_counts
+[EventLoopMonitor] WARNING: Event loop was blocked for 1.2s before executing _update_plot_panel_counts (was queued from WaitControl)
+```
+
+### 2. **PlotPanel Class**
+- Monitors all trait assignments from `__setattr__`
+- Detects cross-thread access to critical Qt traits:
+  - `counts`, `total_counts`, `total_seconds`
+  - `current_cycle`, `current_color`
+  - `is_baseline`, `is_peak_hop`
+  - `_ncounts`, `_ncycles`
+
+**Output when detected:**
+```
+[ThreadSafety.PlotPanel] WARNING: ⚠️  CROSS-THREAD PLOT_PANEL ACCESS: Setting counts from data_collector. 
+Use invoke_in_main_thread() to defer to main thread. This causes M3 ARM64 segfaults.
+```
+
+### 3. **Thread Safety Decorator**
+Use on any function that does Qt operations:
+```python
+from pychron.core.ui.gui import qt_thread_safe
+
+@qt_thread_safe("update plot panel counts")
+def _update_plot_panel(self):
+    self.plot_panel.counts = 5  # Will assert on M3 if called from worker thread
+```
+
+### 4. **assert_main_thread() Function**
+Explicit check for main thread context:
+```python
+from pychron.core.ui.gui import assert_main_thread
+
+def critical_qt_operation(self):
+    assert_main_thread("critical Qt operation")
+    # Safe to do Qt operations here
+    self.plot_panel.counts = value
+```
+
+## Logging Levels and Output
+
+### Thread Safety Logger
+- **Logger Name**: `ThreadSafety`
+- **Related Loggers**: `ThreadSafety.PlotPanel`, `EventLoopMonitor`
+
+### What to Look For in Logs
+
+**1. Normal Deferral (Good)**
+```
+[ThreadSafety] DEBUG: Deferred to main thread: _update_plot_panel_counts from data_collector
+[ThreadSafety] DEBUG: Executing deferred: _update_plot_panel_counts
+```
+
+**2. Cross-Thread Access Detected (Warning)**
+```
+[ThreadSafety.PlotPanel] WARNING: ⚠️  CROSS-THREAD PLOT_PANEL ACCESS: Setting counts from data_collector
+```
+
+**3. Main Thread Blocked (Performance Issue)**
+```
+[EventLoopMonitor] WARNING: ⚠️  Event loop was blocked for 2.5s before executing _update_plot_panel_counts
+```
+
+**4. Exception in Deferred Operation**
+```
+[EventLoopMonitor] Exception in invoke_in_main_thread callback _update_plot_panel_counts
+```
+
+## Debugging M3 Crashes
+
+### If You See a Crash with Pointer Authentication Error
+1. Check logs for thread safety warnings
+2. Look for `CROSS-THREAD PLOT_PANEL ACCESS` messages
+3. Find the offending attribute assignment
+4. Wrap it in `invoke_in_main_thread()`
+
+### Example Crash Diagnostic
+```
+# Crash Log Snippet:
+exception: EXC_BAD_ACCESS (SIGSEGV) "possible pointer authentication failure"
+QCoreApplication::notifyInternal2 → QTimerInfoList::activateTimers()
+
+# Corresponding Log Entry:
+[ThreadSafety.PlotPanel] WARNING: ⚠️  CROSS-THREAD PLOT_PANEL ACCESS: Setting counts from data_collector
+[ThreadSafety] DEBUG: Deferred to main thread: _update_plot_panel_counts from data_collector
+
+# FIX: Check that the operation was actually wrapped in invoke_in_main_thread
+```
+
+## Performance Impact
+
+- **Minimal overhead**: Thread checks are guards (~1-2μs per operation)
+- **Can be disabled**: Set `enable_thread_safety_checks(False)` for production
+- **Recommended**: Keep enabled on M3 development machines for early detection
+
+## Testing on Different Platforms
+
+### Local Development (M3)
+```bash
+# Enable full instrumentation
+PYCHRON_THREAD_SAFETY=1 python -m pychron
+```
+
+### Continuous Integration
+- Run with thread safety checks enabled on M3 CI nodes
+- Check logs for any thread safety warnings
+- File issues if warnings appear
+
+### Regression Testing
+```python
+# In test suite
+def test_measurement_thread_safety():
+    """Verify no cross-thread Qt access during measurement"""
+    from pychron.core.ui.gui import enable_thread_safety_checks
+    enable_thread_safety_checks(True)
+    
+    # Run measurement that collects data
+    # Should not trigger PlotPanel thread safety warnings
+```
+
+## Common Patterns to Fix
+
+### Pattern 1: Direct Plot Panel Update in Collector
+```python
+# ❌ WRONG - causes M3 crash
+class DataCollector:
+    def _measure(self):
+        while measuring:
+            self.automated_run.plot_panel.counts = i
+
+# ✅ RIGHT - safe
+class DataCollector:
+    def _measure(self):
+        while measuring:
+            invoke_in_main_thread(self._update_plot_panel_counts, i)
+    
+    def _update_plot_panel_counts(self, count):
+        if self.automated_run and self.automated_run.plot_panel:
+            self.automated_run.plot_panel.counts = count
+```
+
+### Pattern 2: Graph Operations in Measurement Script
+```python
+# ❌ WRONG - causes M3 crash
+def py_measure(self):
+    g = self.plot_panel.isotope_graph  # Worker thread!
+    g.clear()
+
+# ✅ RIGHT - safe
+def py_measure(self):
+    invoke_in_main_thread(self._setup_graph)
+
+def _setup_graph(self):
+    if self.plot_panel:
+        g = self.plot_panel.isotope_graph
+        g.clear()
+```
+
+### Pattern 3: Multiple Trait Updates
+```python
+# ❌ WRONG - multiple cross-thread accesses
+self.plot_panel.is_baseline = True
+self.plot_panel.show_baseline_graph()
+
+# ✅ RIGHT - batched in one deferred call
+invoke_in_main_thread(self._setup_baseline_on_main_thread)
+
+def _setup_baseline_on_main_thread(self):
+    if self.plot_panel:
+        self.plot_panel.is_baseline = True
+        self.plot_panel.show_baseline_graph()
+```
+
+## Future Work
+
+- [ ] Auto-detection of cross-thread Qt access using AST analysis
+- [ ] CI warnings for any cross-thread access patterns
+- [ ] Performance profiling of defer overhead
+- [ ] Automatic wrapping of suspected violations
+
+## Questions?
+
+Refer to the M3 ARM64 segfault fix documentation: `m3_arm64_segfault_fix.md`

--- a/launchers/launcher.py
+++ b/launchers/launcher.py
@@ -14,6 +14,21 @@
 # limitations under the License.
 # ===============================================================================
 import os
+import sys
+
+# --- Phase 1 M3 diagnostics: install as early as possible, before any Qt
+# object construction, so qInstallMessageHandler and the QTimer thread
+# guard are in place when the rest of the stack imports.
+try:
+    # Ensure pychron is importable even when launched outside Pychron.sh
+    _here = os.path.dirname(os.path.abspath(__file__))
+    _root = os.path.dirname(_here)
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
+    from pychron.core.helpers.m3_diagnostics import install_early as _m3_install_early
+    _m3_install_early()
+except Exception as _e:  # pragma: no cover
+    sys.stderr.write("m3_diagnostics early install failed: %r\n" % (_e,))
 
 from helpers import entry_point
 

--- a/pychron/core/helpers/archiver.py
+++ b/pychron/core/helpers/archiver.py
@@ -125,9 +125,7 @@ class Archiver(HasTraits):
         )
 
     def _clean_archive(self, root):
-        self.info(
-            "Archives older than {} months will be deleted".format(self.archive_months)
-        )
+        self.info("Archives older than {} months will be deleted".format(self.archive_months))
         arch = os.path.join(root, "archive")
         rdate = datetime.today() - timedelta(days=self.archive_months * 30)
 

--- a/pychron/core/helpers/archiver.py
+++ b/pychron/core/helpers/archiver.py
@@ -69,6 +69,9 @@ class Archiver(HasTraits):
     def info(self, msg, *args, **kw):
         logger.info(msg)
 
+    def warning(self, msg, *args, **kw):
+        logger.warning(msg)
+
     def clean(self, exclude=None, **kw):
         self._clean(exclude, **kw)
 
@@ -95,7 +98,8 @@ class Archiver(HasTraits):
 
         for p in f(root):
             rp = os.path.join(root, p)
-            if p in exclude or rp in exclude:
+            # Skip the archive directory itself and any explicitly excluded paths
+            if p == "archive" or p in exclude or rp in exclude:
                 continue
 
             result = os.stat(rp)

--- a/pychron/core/helpers/m3_diagnostics.py
+++ b/pychron/core/helpers/m3_diagnostics.py
@@ -490,6 +490,10 @@ def install_event_tracer() -> None:
                         tid,
                     )
             except Exception:
+                # Tracing must never interfere with event delivery; a
+                # dangling receiver may itself fault on type() lookup
+                # here and that's expected (the unfinished trace line
+                # already tells us a bad receiver is in flight).
                 pass
             return False  # never consume
 

--- a/pychron/core/helpers/m3_diagnostics.py
+++ b/pychron/core/helpers/m3_diagnostics.py
@@ -1,0 +1,473 @@
+# ===============================================================================
+# M3 stability diagnostics (Phase 1: instrumentation only)
+#
+# Adds three independent observers:
+#   1. Qt message handler  -> captures "QObject::startTimer: Timers can only..."
+#      style cross-thread warnings together with the originating Python stack.
+#   2. QTimer thread guard -> logs (with stack) any QTimer constructed from a
+#      non-main Python thread.
+#   3. Main-thread watchdog -> daemon thread that records main-thread heartbeats
+#      driven by a QTimer; if heartbeats stall longer than a threshold it dumps
+#      every Python thread frame.  Detects "spinning beachball" wedges.
+#
+# Output goes to the root logger AND to a dedicated rotating file so the noisy
+# diagnostic stream does not drown the experiment log.
+#
+# This module installs hooks only - it never alters runtime behaviour.  All
+# fixes belong in Phase 2 (cross-thread marshalling).
+# ===============================================================================
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import os
+import sys
+import threading
+import time
+import traceback
+
+_INSTALLED = False
+_WATCHDOG_INSTALLED = False
+_QTIMER_GUARD_INSTALLED = False
+_QT_MSG_HANDLER_INSTALLED = False
+_MARSHALLING_INSTALLED = False
+
+_log = logging.getLogger("pychron.m3_diag")
+_log.setLevel(logging.DEBUG)
+# Do NOT propagate to root: root logger has UI/console handlers, and during
+# paint-heavy code paths (icon loads, tabular paints) Qt can emit dozens of
+# benign warnings (libpng iCCP, image profile, etc.) per second.  Routing
+# those through the root logger stalls the main thread.  Keep diagnostic
+# output in the dedicated file only.
+_log.propagate = False
+
+# Substrings that indicate a real cross-thread Qt violation.  When a Qt
+# warning contains any of these we promote it to ERROR and capture the full
+# Python stack.  Everything else is logged at DEBUG with no stack.
+_XTHREAD_MARKERS = (
+    "Timers can only be used with threads started with QThread",
+    "Timers cannot be stopped from another thread",
+    "Cannot create children for a parent that is in a different thread",
+    "Cannot send events to objects owned by a different thread",
+    "QSocketNotifier: socket notifiers cannot be enabled",
+    "QSocketNotifier: Multiple socket notifiers",
+    "different thread",
+    "another thread",
+)
+
+
+def _get_log_path() -> str:
+    candidates = []
+    env = os.environ.get("PYCHRON_LOG_DIR")
+    if env:
+        candidates.append(env)
+    home = os.path.expanduser("~")
+    candidates.extend(
+        [
+            os.path.join(home, "Pychron", "logs"),
+            os.path.join(home, ".pychron.0", "logs"),
+            home,
+        ]
+    )
+    for d in candidates:
+        try:
+            os.makedirs(d, exist_ok=True)
+            test = os.path.join(d, "m3_diagnostics.log")
+            # touch to verify writable
+            with open(test, "a"):
+                pass
+            return test
+        except OSError:
+            continue
+    return os.path.join(home, "m3_diagnostics.log")
+
+
+def _attach_file_handler() -> None:
+    path = _get_log_path()
+    # rotate at 5 MB, keep 5 backups
+    fh = logging.handlers.RotatingFileHandler(
+        path, maxBytes=5 * 1024 * 1024, backupCount=5
+    )
+    fh.setLevel(logging.DEBUG)
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)s [%(threadName)s] %(message)s"
+    )
+    fh.setFormatter(fmt)
+    _log.addHandler(fh)
+    _log.info("m3_diagnostics file handler attached: %s", path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Qt message handler
+# ---------------------------------------------------------------------------
+def install_qt_message_handler() -> None:
+    """Capture Qt warnings (esp. cross-thread timer/object misuse) with
+    full Python stack and originating thread."""
+    global _QT_MSG_HANDLER_INSTALLED
+    if _QT_MSG_HANDLER_INSTALLED:
+        return
+    try:
+        from pyface.qt.QtCore import qInstallMessageHandler, QtMsgType
+    except Exception as e:  # pragma: no cover
+        _log.error("install_qt_message_handler: import failed: %s", e)
+        return
+
+    _MODE_NAMES = {}
+    for name in (
+        "QtDebugMsg",
+        "QtInfoMsg",
+        "QtWarningMsg",
+        "QtCriticalMsg",
+        "QtFatalMsg",
+        "QtSystemMsg",
+    ):
+        v = getattr(QtMsgType, name, None)
+        if v is not None:
+            _MODE_NAMES[int(v)] = name
+
+    def handler(mode, ctx, msg):
+        try:
+            mode_name = _MODE_NAMES.get(int(mode), str(mode))
+        except Exception:
+            mode_name = str(mode)
+        try:
+            text = str(msg)
+        except Exception:
+            text = repr(msg)
+
+        # Cheap path for the high-volume benign warnings: no thread lookup,
+        # no stack capture, no formatting overhead beyond the log call.
+        is_xthread = any(m in text for m in _XTHREAD_MARKERS)
+        if not is_xthread:
+            # Drop unless explicitly enabled: paint-heavy code paths can emit
+            # dozens of benign Qt warnings per second (libpng iCCP, etc.) and
+            # even writing them to the diag file stalls the main thread.
+            if os.environ.get("PYCHRON_M3_VERBOSE_QT"):
+                _log.debug("QT[%s] %s", mode_name, text)
+            return
+
+        py_thread = threading.current_thread().name
+        is_main = threading.current_thread() is threading.main_thread()
+        loc = ""
+        for attr in ("file", "line", "function"):
+            v = getattr(ctx, attr, None)
+            if v:
+                loc += " %s=%s" % (attr, v)
+        stack = "".join(traceback.format_stack())
+        _log.error(
+            "QT-XTHREAD[%s] %r py_thread=%s main=%s%s\nPYTHON STACK:\n%s",
+            mode_name,
+            text,
+            py_thread,
+            is_main,
+            loc,
+            stack,
+        )
+
+    qInstallMessageHandler(handler)
+    _QT_MSG_HANDLER_INSTALLED = True
+    _log.info("Qt message handler installed")
+
+
+# ---------------------------------------------------------------------------
+# 2. QTimer thread guard
+# ---------------------------------------------------------------------------
+def install_qtimer_thread_guard() -> None:
+    """Wrap QTimer.__init__ and QTimer.singleShot so any non-main-thread use
+    is logged with stack."""
+    global _QTIMER_GUARD_INSTALLED
+    if _QTIMER_GUARD_INSTALLED:
+        return
+    try:
+        from pyface.qt.QtCore import QTimer
+    except Exception as e:  # pragma: no cover
+        _log.error("install_qtimer_thread_guard: import failed: %s", e)
+        return
+
+    orig_init = QTimer.__init__
+    orig_single_shot = QTimer.singleShot
+
+    def init_wrapper(self, *args, **kwargs):
+        if threading.current_thread() is not threading.main_thread():
+            _log.error(
+                "QTimer() constructed off main thread (thread=%s)\n%s",
+                threading.current_thread().name,
+                "".join(traceback.format_stack()),
+            )
+        return orig_init(self, *args, **kwargs)
+
+    @staticmethod
+    def single_shot_wrapper(*args, **kwargs):
+        if threading.current_thread() is not threading.main_thread():
+            _log.error(
+                "QTimer.singleShot called off main thread (thread=%s)\n%s",
+                threading.current_thread().name,
+                "".join(traceback.format_stack()),
+            )
+        return orig_single_shot(*args, **kwargs)
+
+    try:
+        QTimer.__init__ = init_wrapper
+        QTimer.singleShot = single_shot_wrapper
+        _QTIMER_GUARD_INSTALLED = True
+        _log.info("QTimer thread guard installed")
+    except (TypeError, AttributeError) as e:
+        # PyQt/PySide may forbid replacing C++ slot wrappers.  Fall back to
+        # a __init_subclass__-style check by hooking the metaclass would be
+        # overkill; just log and continue - Qt message handler will still
+        # catch the underlying startTimer warnings.
+        _log.warning("QTimer thread guard could not be installed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# 3. Main-thread watchdog
+# ---------------------------------------------------------------------------
+class _Watchdog:
+    def __init__(self, stall_threshold: float = 2.0,
+                 dump_cooldown: float = 10.0,
+                 heartbeat_ms: int = 500):
+        self.stall_threshold = stall_threshold
+        self.dump_cooldown = dump_cooldown
+        self.heartbeat_ms = heartbeat_ms
+        self.last_heartbeat = time.monotonic()
+        self.last_dump = 0.0
+        self.timer = None
+        self._poll_thread = None
+
+    def _on_heartbeat(self):
+        self.last_heartbeat = time.monotonic()
+
+    def _poll(self):
+        # rate: 4x per second
+        while True:
+            time.sleep(0.25)
+            now = time.monotonic()
+            gap = now - self.last_heartbeat
+            if gap >= self.stall_threshold and (now - self.last_dump) >= self.dump_cooldown:
+                self.last_dump = now
+                self._dump(gap)
+
+    def _dump(self, gap: float):
+        try:
+            frames = sys._current_frames()
+            lines = ["MAIN-THREAD STALL %.2fs (threshold %.2fs)" %
+                     (gap, self.stall_threshold)]
+            # Map thread ids -> Thread objects for names
+            by_id = {t.ident: t for t in threading.enumerate()}
+            for tid, frame in frames.items():
+                t = by_id.get(tid)
+                tname = t.name if t else "tid=%s" % tid
+                is_main = bool(t and t is threading.main_thread())
+                lines.append(
+                    "---- Thread %s%s ----" %
+                    (tname, " (MAIN)" if is_main else "")
+                )
+                lines.extend(traceback.format_stack(frame))
+            _log.error("\n".join(lines))
+        except Exception as e:  # pragma: no cover
+            _log.exception("watchdog dump failed: %s", e)
+
+    def start_main_timer(self):
+        # called from main thread once QApplication exists
+        try:
+            from pyface.qt.QtCore import QTimer
+        except Exception as e:  # pragma: no cover
+            _log.error("watchdog: QTimer import failed: %s", e)
+            return
+        self.timer = QTimer()
+        self.timer.setInterval(self.heartbeat_ms)
+        self.timer.timeout.connect(self._on_heartbeat)
+        self.timer.start()
+        _log.info("watchdog: main-thread heartbeat QTimer started (%d ms)",
+                  self.heartbeat_ms)
+
+    def start_poll_thread(self):
+        self._poll_thread = threading.Thread(
+            target=self._poll, name="M3Watchdog", daemon=True
+        )
+        self._poll_thread.start()
+        _log.info(
+            "watchdog: poll thread started (stall=%.1fs, cooldown=%.1fs)",
+            self.stall_threshold,
+            self.dump_cooldown,
+        )
+
+
+_watchdog: _Watchdog | None = None
+
+
+# ---------------------------------------------------------------------------
+# 4. Phase 2 cross-thread marshalling
+#
+# Worker threads (run threads, _do_collection, etc.) frequently end up
+# scheduling Qt timers via pyface helpers such as do_after_timer.  On macOS
+# ARM64 these timers are bound to whichever Qt thread context happened to
+# be active when they were started; once the worker thread exits, the
+# QObject's parent context is gone and the next time the timer fires Qt
+# dereferences a stale pointer, which on M3 triggers a PAC fault and
+# SIGBUS/SIGSEGV.  Intel silently dereferences the garbage and limps on,
+# Apple Silicon does not.
+#
+# The fix is to force every Qt-timer scheduling helper to run on the main
+# thread.  We patch the three documented entry points used by pychron and
+# its dependencies.  Caller behaviour is preserved when already on the
+# main thread; when called off-main, the scheduling is deferred to the
+# main thread via pychron.core.ui.gui.invoke_in_main_thread (which
+# ultimately uses GUI.invoke_later -> Qt queued connection).  The
+# *callable* the caller passed to do_after_timer still runs on the main
+# thread, so any UI code it touches is now thread-correct.
+# ---------------------------------------------------------------------------
+def _on_main_thread() -> bool:
+    return threading.current_thread() is threading.main_thread()
+
+
+def _marshal(fn, *args, **kwargs):
+    """Run fn on the main thread (deferred).  Returns None synchronously."""
+    from pychron.core.ui.gui import invoke_in_main_thread
+    invoke_in_main_thread(fn, *args, **kwargs)
+    return None
+
+
+def install_thread_safe_marshalling() -> None:
+    """Patch pyface timer entry points so off-main-thread callers no longer
+    create QTimers bound to dying worker thread contexts."""
+    global _MARSHALLING_INSTALLED
+    if _MARSHALLING_INSTALLED:
+        return
+
+    patched = []
+
+    # --- pyface.timer.do_later.do_after / do_later ----------------------------
+    try:
+        import pyface.timer.do_later as _dl
+
+        if hasattr(_dl, "do_after"):
+            _orig_do_after = _dl.do_after
+
+            def _safe_do_after(ms, callable_, *a, **kw):
+                if _on_main_thread():
+                    return _orig_do_after(ms, callable_, *a, **kw)
+                _log.debug(
+                    "marshalling do_after from %s",
+                    threading.current_thread().name,
+                )
+                return _marshal(_orig_do_after, ms, callable_, *a, **kw)
+
+            _dl.do_after = _safe_do_after
+            patched.append("pyface.timer.do_later.do_after")
+
+        if hasattr(_dl, "do_later"):
+            _orig_do_later = _dl.do_later
+
+            def _safe_do_later(callable_, *a, **kw):
+                if _on_main_thread():
+                    return _orig_do_later(callable_, *a, **kw)
+                _log.debug(
+                    "marshalling do_later from %s",
+                    threading.current_thread().name,
+                )
+                return _marshal(_orig_do_later, callable_, *a, **kw)
+
+            _dl.do_later = _safe_do_later
+            patched.append("pyface.timer.do_later.do_later")
+    except Exception as e:  # pragma: no cover
+        _log.error("marshalling: pyface.timer.do_later patch failed: %s", e)
+
+    # --- pyface.timer.i_timer.CallbackTimer.single_shot -----------------------
+    # do_after_timer routes through CallbackTimer.single_shot, but other
+    # call sites (e.g. ITimer.single_shot used by traitsui editors) also do.
+    # Patch the classmethod on the implementation class to catch every path.
+    try:
+        from pyface.timer.timer import CallbackTimer as _CBT
+
+        _orig_single_shot = _CBT.single_shot
+
+        def _safe_single_shot(cls, *a, **kw):
+            if _on_main_thread():
+                return _orig_single_shot.__func__(cls, *a, **kw)
+            _log.debug(
+                "marshalling CallbackTimer.single_shot from %s",
+                threading.current_thread().name,
+            )
+            return _marshal(_orig_single_shot.__func__, cls, *a, **kw)
+
+        _CBT.single_shot = classmethod(_safe_single_shot)
+        patched.append("pyface.timer.i_timer.CallbackTimer.single_shot")
+    except Exception as e:  # pragma: no cover
+        _log.error("marshalling: CallbackTimer.single_shot patch failed: %s", e)
+
+    # --- pyface.qt.QtCore.QTimer.singleShot ----------------------------------
+    # Lowest level: any direct PyQt/PySide QTimer.singleShot call from a
+    # worker thread.  The earlier Phase 1 guard only logged; now marshal.
+    try:
+        from pyface.qt.QtCore import QTimer
+
+        _orig_qt_single_shot = QTimer.singleShot
+
+        @staticmethod
+        def _safe_qt_single_shot(*a, **kw):
+            if _on_main_thread():
+                return _orig_qt_single_shot(*a, **kw)
+            _log.debug(
+                "marshalling QTimer.singleShot from %s",
+                threading.current_thread().name,
+            )
+            return _marshal(_orig_qt_single_shot, *a, **kw)
+
+        try:
+            QTimer.singleShot = _safe_qt_single_shot
+            patched.append("pyface.qt.QtCore.QTimer.singleShot")
+        except (TypeError, AttributeError) as e:
+            _log.warning(
+                "marshalling: QTimer.singleShot replacement rejected by "
+                "PyQt/PySide binding: %s",
+                e,
+            )
+    except Exception as e:  # pragma: no cover
+        _log.error("marshalling: QTimer.singleShot patch failed: %s", e)
+
+    _MARSHALLING_INSTALLED = True
+    _log.info("thread-safe marshalling installed: %s", ", ".join(patched))
+
+
+def install_main_thread_watchdog(stall_threshold: float = 2.0) -> None:
+    """Start the watchdog poll thread immediately and arm the main-thread
+    QTimer.  Must be called from the main thread, after the QApplication has
+    been constructed but before its event loop is exec'd."""
+    global _watchdog, _WATCHDOG_INSTALLED
+    if _WATCHDOG_INSTALLED:
+        return
+    _watchdog = _Watchdog(stall_threshold=stall_threshold)
+    _watchdog.start_main_timer()
+    _watchdog.start_poll_thread()
+    _WATCHDOG_INSTALLED = True
+
+
+# ---------------------------------------------------------------------------
+# top-level entry points
+# ---------------------------------------------------------------------------
+def install_early() -> None:
+    """Install everything that does not need a running QApplication.
+    Call as early as possible (before any Qt object is constructed)."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _attach_file_handler()
+    install_qt_message_handler()
+    install_qtimer_thread_guard()
+    _INSTALLED = True
+    _log.info("m3_diagnostics: early install complete (pid=%d)", os.getpid())
+
+
+def install_late(stall_threshold: float = 5.0) -> None:
+    """Install hooks that require a constructed QApplication.  Call right
+    after app_factory() and before app.run().
+
+    Phase 2 marshalling is also installed here (technically it does not
+    require a running QApplication, but it does require pyface to be fully
+    imported, which is only guaranteed once app_factory has run)."""
+    install_thread_safe_marshalling()
+    install_main_thread_watchdog(stall_threshold=stall_threshold)
+
+
+# ============= EOF =============================================

--- a/pychron/core/helpers/m3_diagnostics.py
+++ b/pychron/core/helpers/m3_diagnostics.py
@@ -85,13 +85,9 @@ def _get_log_path() -> str:
 def _attach_file_handler() -> None:
     path = _get_log_path()
     # rotate at 5 MB, keep 5 backups
-    fh = logging.handlers.RotatingFileHandler(
-        path, maxBytes=5 * 1024 * 1024, backupCount=5
-    )
+    fh = logging.handlers.RotatingFileHandler(path, maxBytes=5 * 1024 * 1024, backupCount=5)
     fh.setLevel(logging.DEBUG)
-    fmt = logging.Formatter(
-        "%(asctime)s %(levelname)s [%(threadName)s] %(message)s"
-    )
+    fmt = logging.Formatter("%(asctime)s %(levelname)s [%(threadName)s] %(message)s")
     fh.setFormatter(fmt)
     _log.addHandler(fh)
     _log.info("m3_diagnostics file handler attached: %s", path)
@@ -196,7 +192,6 @@ def install_qtimer_thread_guard() -> None:
             )
         return orig_init(self, *args, **kwargs)
 
-    @staticmethod
     def single_shot_wrapper(*args, **kwargs):
         if threading.current_thread() is not threading.main_thread():
             _log.error(
@@ -223,9 +218,9 @@ def install_qtimer_thread_guard() -> None:
 # 3. Main-thread watchdog
 # ---------------------------------------------------------------------------
 class _Watchdog:
-    def __init__(self, stall_threshold: float = 2.0,
-                 dump_cooldown: float = 10.0,
-                 heartbeat_ms: int = 500):
+    def __init__(
+        self, stall_threshold: float = 2.0, dump_cooldown: float = 10.0, heartbeat_ms: int = 500
+    ):
         self.stall_threshold = stall_threshold
         self.dump_cooldown = dump_cooldown
         self.heartbeat_ms = heartbeat_ms
@@ -250,18 +245,14 @@ class _Watchdog:
     def _dump(self, gap: float):
         try:
             frames = sys._current_frames()
-            lines = ["MAIN-THREAD STALL %.2fs (threshold %.2fs)" %
-                     (gap, self.stall_threshold)]
+            lines = ["MAIN-THREAD STALL %.2fs (threshold %.2fs)" % (gap, self.stall_threshold)]
             # Map thread ids -> Thread objects for names
             by_id = {t.ident: t for t in threading.enumerate()}
             for tid, frame in frames.items():
                 t = by_id.get(tid)
                 tname = t.name if t else "tid=%s" % tid
                 is_main = bool(t and t is threading.main_thread())
-                lines.append(
-                    "---- Thread %s%s ----" %
-                    (tname, " (MAIN)" if is_main else "")
-                )
+                lines.append("---- Thread %s%s ----" % (tname, " (MAIN)" if is_main else ""))
                 lines.extend(traceback.format_stack(frame))
             _log.error("\n".join(lines))
         except Exception as e:  # pragma: no cover
@@ -278,13 +269,10 @@ class _Watchdog:
         self.timer.setInterval(self.heartbeat_ms)
         self.timer.timeout.connect(self._on_heartbeat)
         self.timer.start()
-        _log.info("watchdog: main-thread heartbeat QTimer started (%d ms)",
-                  self.heartbeat_ms)
+        _log.info("watchdog: main-thread heartbeat QTimer started (%d ms)", self.heartbeat_ms)
 
     def start_poll_thread(self):
-        self._poll_thread = threading.Thread(
-            target=self._poll, name="M3Watchdog", daemon=True
-        )
+        self._poll_thread = threading.Thread(target=self._poll, name="M3Watchdog", daemon=True)
         self._poll_thread.start()
         _log.info(
             "watchdog: poll thread started (stall=%.1fs, cooldown=%.1fs)",
@@ -324,6 +312,7 @@ def _on_main_thread() -> bool:
 def _marshal(fn, *args, **kwargs):
     """Run fn on the main thread (deferred).  Returns None synchronously."""
     from pychron.core.ui.gui import invoke_in_main_thread
+
     invoke_in_main_thread(fn, *args, **kwargs)
     return None
 
@@ -404,7 +393,6 @@ def install_thread_safe_marshalling() -> None:
 
         _orig_qt_single_shot = QTimer.singleShot
 
-        @staticmethod
         def _safe_qt_single_shot(*a, **kw):
             if _on_main_thread():
                 return _orig_qt_single_shot(*a, **kw)
@@ -419,8 +407,7 @@ def install_thread_safe_marshalling() -> None:
             patched.append("pyface.qt.QtCore.QTimer.singleShot")
         except (TypeError, AttributeError) as e:
             _log.warning(
-                "marshalling: QTimer.singleShot replacement rejected by "
-                "PyQt/PySide binding: %s",
+                "marshalling: QTimer.singleShot replacement rejected by " "PyQt/PySide binding: %s",
                 e,
             )
     except Exception as e:  # pragma: no cover
@@ -457,9 +444,7 @@ def install_event_tracer() -> None:
 
     app = QCoreApplication.instance()
     if app is None:
-        _log.error(
-            "install_event_tracer: no QApplication instance; call after app_factory"
-        )
+        _log.error("install_event_tracer: no QApplication instance; call after app_factory")
         return
 
     # Dedicated logger + rotating file so the trace volume does not pollute
@@ -469,17 +454,14 @@ def install_event_tracer() -> None:
     trace_logger.setLevel(logging.DEBUG)
     trace_logger.propagate = False
     if not trace_logger.handlers:
-        trace_path = os.path.join(
-            os.path.dirname(_get_log_path()), "m3_eventtrace.log"
-        )
+        trace_path = os.path.join(os.path.dirname(_get_log_path()), "m3_eventtrace.log")
         try:
             fh = logging.handlers.RotatingFileHandler(
                 trace_path, maxBytes=5 * 1024 * 1024, backupCount=3
             )
             fh.setLevel(logging.DEBUG)
             fh.setFormatter(
-                logging.Formatter("%(asctime)s.%(msecs)03d %(message)s",
-                                  datefmt="%H:%M:%S")
+                logging.Formatter("%(asctime)s.%(msecs)03d %(message)s", datefmt="%H:%M:%S")
             )
             trace_logger.addHandler(fh)
         except OSError as e:

--- a/pychron/core/helpers/m3_diagnostics.py
+++ b/pychron/core/helpers/m3_diagnostics.py
@@ -430,6 +430,98 @@ def install_thread_safe_marshalling() -> None:
     _log.info("thread-safe marshalling installed: %s", ", ".join(patched))
 
 
+_EVENT_TRACER_INSTALLED = False
+_event_tracer = None  # keep a strong ref so Qt doesn't GC the filter
+
+
+def install_event_tracer() -> None:
+    """Install a QApplication-level event filter that logs every Qt Timer
+    event delivery to a dedicated rotating file (m3_eventtrace.log).
+
+    Each line: timestamp + receiver class name + receiver Python id +
+    timer_id (where exposed by the binding).  When the process segfaults
+    inside QCoreApplication::notifyInternal2, the last few lines of this
+    file identify which receiver class was about to be dispatched to.
+
+    Volume control: only Timer events are traced (Qt event type 1).  The
+    full event stream is far too noisy to dump per delivery.
+    """
+    global _EVENT_TRACER_INSTALLED, _event_tracer
+    if _EVENT_TRACER_INSTALLED:
+        return
+    try:
+        from pyface.qt.QtCore import QObject, QEvent, QCoreApplication
+    except Exception as e:  # pragma: no cover
+        _log.error("install_event_tracer: import failed: %s", e)
+        return
+
+    app = QCoreApplication.instance()
+    if app is None:
+        _log.error(
+            "install_event_tracer: no QApplication instance; call after app_factory"
+        )
+        return
+
+    # Dedicated logger + rotating file so the trace volume does not pollute
+    # the main diagnostics log.  Unbuffered (flush per line) so the most
+    # recent receivers survive a SIGSEGV.
+    trace_logger = logging.getLogger("pychron.m3_diag.eventtrace")
+    trace_logger.setLevel(logging.DEBUG)
+    trace_logger.propagate = False
+    if not trace_logger.handlers:
+        trace_path = os.path.join(
+            os.path.dirname(_get_log_path()), "m3_eventtrace.log"
+        )
+        try:
+            fh = logging.handlers.RotatingFileHandler(
+                trace_path, maxBytes=5 * 1024 * 1024, backupCount=3
+            )
+            fh.setLevel(logging.DEBUG)
+            fh.setFormatter(
+                logging.Formatter("%(asctime)s.%(msecs)03d %(message)s",
+                                  datefmt="%H:%M:%S")
+            )
+            trace_logger.addHandler(fh)
+        except OSError as e:
+            _log.error("install_event_tracer: log open failed: %s", e)
+            return
+
+    TIMER_EVT = int(QEvent.Timer)
+
+    class _EventTracer(QObject):
+        def eventFilter(self, obj, ev):
+            try:
+                if int(ev.type()) == TIMER_EVT:
+                    try:
+                        tid = ev.timerId()
+                    except Exception:
+                        tid = -1
+                    # Capture receiver class + id() BEFORE Qt dispatches.
+                    # If receiver is already dangling, accessing type(obj)
+                    # may itself fault - but a faulting trace point still
+                    # tells us we got here, and a successful one identifies
+                    # the next dispatch target.
+                    trace_logger.debug(
+                        "Timer cls=%s pyid=0x%x qtid=%d",
+                        type(obj).__name__,
+                        id(obj),
+                        tid,
+                    )
+            except Exception:
+                pass
+            return False  # never consume
+
+    _event_tracer = _EventTracer()
+    try:
+        app.installEventFilter(_event_tracer)
+    except Exception as e:
+        _log.error("install_event_tracer: installEventFilter failed: %s", e)
+        return
+
+    _EVENT_TRACER_INSTALLED = True
+    _log.info("event tracer installed (Timer events -> m3_eventtrace.log)")
+
+
 def install_main_thread_watchdog(stall_threshold: float = 2.0) -> None:
     """Start the watchdog poll thread immediately and arm the main-thread
     QTimer.  Must be called from the main thread, after the QApplication has
@@ -468,6 +560,12 @@ def install_late(stall_threshold: float = 5.0) -> None:
     imported, which is only guaranteed once app_factory has run)."""
     install_thread_safe_marshalling()
     install_main_thread_watchdog(stall_threshold=stall_threshold)
+    # Event tracer is opt-in: it logs one line per Timer event delivered
+    # on the main thread, which is verbose.  Enable when hunting a crash
+    # inside QCoreApplication::notifyInternal2 by setting
+    # PYCHRON_M3_EVENT_TRACE=1 in the environment.
+    if os.environ.get("PYCHRON_M3_EVENT_TRACE"):
+        install_event_tracer()
 
 
 # ============= EOF =============================================

--- a/pychron/core/ui/crash_diagnostics.py
+++ b/pychron/core/ui/crash_diagnostics.py
@@ -1,0 +1,207 @@
+# ===============================================================================
+# Copyright 2026 Jake Ross
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+"""
+Crash Diagnostics for M3/ARM64 Segmentation Faults
+
+Provides tools to analyze and diagnose segmentation faults caused by cross-thread
+Qt access on Apple Silicon (M3) Macs with pointer authentication.
+
+Usage:
+    from pychron.core.ui.crash_diagnostics import analyze_crash_log
+    
+    # Analyze a crash report
+    with open("crash.log") as f:
+        analysis = analyze_crash_log(f.read())
+        print(analysis.summary())
+"""
+
+import re
+from typing import Dict, List, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class CrashAnalysis:
+    """Analysis results from a crash log."""
+    is_m3_segfault: bool
+    is_pointer_auth_failure: bool
+    crash_in_qt_event_loop: bool
+    suspected_cross_thread_access: bool
+    stack_trace_lines: List[str]
+    
+    def summary(self) -> str:
+        """Generate a summary of the crash analysis."""
+        lines = ["=== M3 Crash Diagnostics ===\n"]
+        
+        if self.is_m3_segfault:
+            lines.append("❌ M3/ARM64 Segmentation Fault Detected\n")
+            
+        if self.is_pointer_auth_failure:
+            lines.append("⚠️  POINTER AUTHENTICATION FAILURE\n")
+            lines.append("   This occurs when invalid Qt objects are accessed from worker threads.\n")
+            lines.append("   Solution: Wrap cross-thread Qt operations in invoke_in_main_thread()\n\n")
+        
+        if self.crash_in_qt_event_loop:
+            lines.append("📍 Crash Location: Qt Event Loop (QCoreApplication::notifyInternal2)\n")
+            lines.append("   Likely cause: Qt timer or signal from worker thread\n\n")
+        
+        if self.suspected_cross_thread_access:
+            lines.append("🔍 Suspected cross-thread access detected\n")
+            lines.append("   Check the following stack frames for plot_panel or graph operations\n\n")
+        
+        if self.stack_trace_lines:
+            lines.append("Stack Trace (Key Frames):\n")
+            for line in self.stack_trace_lines[:10]:  # Show first 10 frames
+                lines.append(f"  {line}\n")
+        
+        lines.append("\nReferenced Files:\n")
+        lines.append("  - M3_INSTRUMENTATION.md - How to enable crash diagnostics\n")
+        lines.append("  - m3_arm64_segfault_fix.md - Details of the fix\n")
+        
+        return "".join(lines)
+
+
+def analyze_crash_log(log_content: str) -> CrashAnalysis:
+    """Analyze a crash log for M3/ARM64 segmentation faults.
+    
+    Args:
+        log_content: Contents of the crash log file
+        
+    Returns:
+        CrashAnalysis with detection results
+    """
+    is_m3_segfault = False
+    is_pointer_auth_failure = False
+    crash_in_qt_event_loop = False
+    suspected_cross_thread_access = False
+    stack_trace_lines = []
+    
+    lines = log_content.split('\n')
+    
+    # Check for ARM64 and segfault indicators
+    if 'arm64' in log_content.lower() or 'ARM-64' in log_content:
+        is_m3_segfault = True
+    
+    if 'segmentation fault' in log_content.lower() or 'sigsegv' in log_content.lower():
+        is_m3_segfault = True
+    
+    # Check for pointer authentication failure (key indicator)
+    if 'pointer authentication failure' in log_content.lower():
+        is_pointer_auth_failure = True
+        is_m3_segfault = True
+    
+    # Check for Qt event loop in crash context
+    if 'qcoreapplication' in log_content.lower() or 'qtimerinfo' in log_content.lower():
+        crash_in_qt_event_loop = True
+    
+    # Look for suspicious Qt operations
+    suspicious_patterns = [
+        r'plot_panel',
+        r'isotope_graph',
+        r'baseline_graph',
+        r'\.counts',
+        r'\.trait_set',
+        r'\.counts\s*=',
+        r'\.update\(\)',
+    ]
+    
+    for pattern in suspicious_patterns:
+        if re.search(pattern, log_content):
+            suspected_cross_thread_access = True
+            break
+    
+    # Extract stack trace
+    in_stack = False
+    for line in lines:
+        if 'thread' in line.lower() or 'frame' in line.lower():
+            in_stack = True
+        elif in_stack and line.strip():
+            # Look for function names in stack
+            if any(x in line for x in ['(', ')', '0x', '+']):
+                stack_trace_lines.append(line.strip())
+                if len(stack_trace_lines) >= 10:
+                    break
+    
+    return CrashAnalysis(
+        is_m3_segfault=is_m3_segfault,
+        is_pointer_auth_failure=is_pointer_auth_failure,
+        crash_in_qt_event_loop=crash_in_qt_event_loop,
+        suspected_cross_thread_access=suspected_cross_thread_access,
+        stack_trace_lines=stack_trace_lines,
+    )
+
+
+def suggest_fixes(analysis: CrashAnalysis) -> List[str]:
+    """Suggest fixes based on crash analysis.
+    
+    Args:
+        analysis: CrashAnalysis results
+        
+    Returns:
+        List of suggested fixes
+    """
+    suggestions = []
+    
+    if analysis.is_pointer_auth_failure:
+        suggestions.append(
+            "1. Check for direct plot_panel/graph access from worker threads\n"
+            "   Solution: Use invoke_in_main_thread() to defer to main thread"
+        )
+        suggestions.append(
+            "2. Search for pattern: self.plot_panel.<attribute> = <value>\n"
+            "   These should be wrapped in invoke_in_main_thread()"
+        )
+        suggestions.append(
+            "3. Check data_collector.py and peak_hop_collector.py\n"
+            "   These are common sources of cross-thread access"
+        )
+    
+    if analysis.crash_in_qt_event_loop:
+        suggestions.append(
+            "4. The crash is in Qt's event loop\n"
+            "   This indicates Qt state corruption from another thread"
+        )
+    
+    if analysis.suspected_cross_thread_access:
+        suggestions.append(
+            "5. Suspected cross-thread Qt access detected in stack trace\n"
+            "   Review the identified frames for plot_panel operations"
+        )
+    
+    if not suggestions:
+        suggestions.append(
+            "Unable to identify specific cause.\n"
+            "Check thread safety logs for CROSS-THREAD PLOT_PANEL ACCESS warnings."
+        )
+    
+    return suggestions
+
+
+if __name__ == '__main__':
+    import sys
+    
+    if len(sys.argv) > 1:
+        crash_file = sys.argv[1]
+        with open(crash_file) as f:
+            content = f.read()
+        
+        analysis = analyze_crash_log(content)
+        print(analysis.summary())
+        print("\nSuggested Fixes:")
+        for suggestion in suggest_fixes(analysis):
+            print(suggestion)
+    else:
+        print("Usage: python crash_diagnostics.py <crash_log_file>")

--- a/pychron/core/ui/crash_diagnostics.py
+++ b/pychron/core/ui/crash_diagnostics.py
@@ -21,7 +21,7 @@ Qt access on Apple Silicon (M3) Macs with pointer authentication.
 
 Usage:
     from pychron.core.ui.crash_diagnostics import analyze_crash_log
-    
+
     # Analyze a crash report
     with open("crash.log") as f:
         analysis = analyze_crash_log(f.read())
@@ -29,57 +29,64 @@ Usage:
 """
 
 import re
-from typing import Dict, List, Optional
+from typing import List
 from dataclasses import dataclass
 
 
 @dataclass
 class CrashAnalysis:
     """Analysis results from a crash log."""
+
     is_m3_segfault: bool
     is_pointer_auth_failure: bool
     crash_in_qt_event_loop: bool
     suspected_cross_thread_access: bool
     stack_trace_lines: List[str]
-    
+
     def summary(self) -> str:
         """Generate a summary of the crash analysis."""
         lines = ["=== M3 Crash Diagnostics ===\n"]
-        
+
         if self.is_m3_segfault:
             lines.append("❌ M3/ARM64 Segmentation Fault Detected\n")
-            
+
         if self.is_pointer_auth_failure:
             lines.append("⚠️  POINTER AUTHENTICATION FAILURE\n")
-            lines.append("   This occurs when invalid Qt objects are accessed from worker threads.\n")
-            lines.append("   Solution: Wrap cross-thread Qt operations in invoke_in_main_thread()\n\n")
-        
+            lines.append(
+                "   This occurs when invalid Qt objects are accessed from worker threads.\n"
+            )
+            lines.append(
+                "   Solution: Wrap cross-thread Qt operations in invoke_in_main_thread()\n\n"
+            )
+
         if self.crash_in_qt_event_loop:
             lines.append("📍 Crash Location: Qt Event Loop (QCoreApplication::notifyInternal2)\n")
             lines.append("   Likely cause: Qt timer or signal from worker thread\n\n")
-        
+
         if self.suspected_cross_thread_access:
             lines.append("🔍 Suspected cross-thread access detected\n")
-            lines.append("   Check the following stack frames for plot_panel or graph operations\n\n")
-        
+            lines.append(
+                "   Check the following stack frames for plot_panel or graph operations\n\n"
+            )
+
         if self.stack_trace_lines:
             lines.append("Stack Trace (Key Frames):\n")
             for line in self.stack_trace_lines[:10]:  # Show first 10 frames
                 lines.append(f"  {line}\n")
-        
+
         lines.append("\nReferenced Files:\n")
         lines.append("  - M3_INSTRUMENTATION.md - How to enable crash diagnostics\n")
         lines.append("  - m3_arm64_segfault_fix.md - Details of the fix\n")
-        
+
         return "".join(lines)
 
 
 def analyze_crash_log(log_content: str) -> CrashAnalysis:
     """Analyze a crash log for M3/ARM64 segmentation faults.
-    
+
     Args:
         log_content: Contents of the crash log file
-        
+
     Returns:
         CrashAnalysis with detection results
     """
@@ -88,53 +95,53 @@ def analyze_crash_log(log_content: str) -> CrashAnalysis:
     crash_in_qt_event_loop = False
     suspected_cross_thread_access = False
     stack_trace_lines = []
-    
-    lines = log_content.split('\n')
-    
+
+    lines = log_content.split("\n")
+
     # Check for ARM64 and segfault indicators
-    if 'arm64' in log_content.lower() or 'ARM-64' in log_content:
+    if "arm64" in log_content.lower() or "ARM-64" in log_content:
         is_m3_segfault = True
-    
-    if 'segmentation fault' in log_content.lower() or 'sigsegv' in log_content.lower():
+
+    if "segmentation fault" in log_content.lower() or "sigsegv" in log_content.lower():
         is_m3_segfault = True
-    
+
     # Check for pointer authentication failure (key indicator)
-    if 'pointer authentication failure' in log_content.lower():
+    if "pointer authentication failure" in log_content.lower():
         is_pointer_auth_failure = True
         is_m3_segfault = True
-    
+
     # Check for Qt event loop in crash context
-    if 'qcoreapplication' in log_content.lower() or 'qtimerinfo' in log_content.lower():
+    if "qcoreapplication" in log_content.lower() or "qtimerinfo" in log_content.lower():
         crash_in_qt_event_loop = True
-    
+
     # Look for suspicious Qt operations
     suspicious_patterns = [
-        r'plot_panel',
-        r'isotope_graph',
-        r'baseline_graph',
-        r'\.counts',
-        r'\.trait_set',
-        r'\.counts\s*=',
-        r'\.update\(\)',
+        r"plot_panel",
+        r"isotope_graph",
+        r"baseline_graph",
+        r"\.counts",
+        r"\.trait_set",
+        r"\.counts\s*=",
+        r"\.update\(\)",
     ]
-    
+
     for pattern in suspicious_patterns:
         if re.search(pattern, log_content):
             suspected_cross_thread_access = True
             break
-    
+
     # Extract stack trace
     in_stack = False
     for line in lines:
-        if 'thread' in line.lower() or 'frame' in line.lower():
+        if "thread" in line.lower() or "frame" in line.lower():
             in_stack = True
         elif in_stack and line.strip():
             # Look for function names in stack
-            if any(x in line for x in ['(', ')', '0x', '+']):
+            if any(x in line for x in ["(", ")", "0x", "+"]):
                 stack_trace_lines.append(line.strip())
                 if len(stack_trace_lines) >= 10:
                     break
-    
+
     return CrashAnalysis(
         is_m3_segfault=is_m3_segfault,
         is_pointer_auth_failure=is_pointer_auth_failure,
@@ -146,15 +153,15 @@ def analyze_crash_log(log_content: str) -> CrashAnalysis:
 
 def suggest_fixes(analysis: CrashAnalysis) -> List[str]:
     """Suggest fixes based on crash analysis.
-    
+
     Args:
         analysis: CrashAnalysis results
-        
+
     Returns:
         List of suggested fixes
     """
     suggestions = []
-    
+
     if analysis.is_pointer_auth_failure:
         suggestions.append(
             "1. Check for direct plot_panel/graph access from worker threads\n"
@@ -168,36 +175,36 @@ def suggest_fixes(analysis: CrashAnalysis) -> List[str]:
             "3. Check data_collector.py and peak_hop_collector.py\n"
             "   These are common sources of cross-thread access"
         )
-    
+
     if analysis.crash_in_qt_event_loop:
         suggestions.append(
             "4. The crash is in Qt's event loop\n"
             "   This indicates Qt state corruption from another thread"
         )
-    
+
     if analysis.suspected_cross_thread_access:
         suggestions.append(
             "5. Suspected cross-thread Qt access detected in stack trace\n"
             "   Review the identified frames for plot_panel operations"
         )
-    
+
     if not suggestions:
         suggestions.append(
             "Unable to identify specific cause.\n"
             "Check thread safety logs for CROSS-THREAD PLOT_PANEL ACCESS warnings."
         )
-    
+
     return suggestions
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) > 1:
         crash_file = sys.argv[1]
         with open(crash_file) as f:
             content = f.read()
-        
+
         analysis = analyze_crash_log(content)
         print(analysis.summary())
         print("\nSuggested Fixes:")

--- a/pychron/core/ui/factory.py
+++ b/pychron/core/ui/factory.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import
 from traits.etsconfig.api import ETSConfig
 
-
 # ============= standard library imports ========================
 # ============= local library imports  ==========================
 
@@ -28,7 +27,7 @@ from traits.etsconfig.api import ETSConfig
 
 def toolkit_factory(name, klass=None):
     """Factory for getting toolkit-specific classes.
-    
+
     Returns the requested class immediately (eager loading).
     This ensures all Qt classes are available for menu initialization.
     """
@@ -36,10 +35,10 @@ def toolkit_factory(name, klass=None):
         raise NotImplementedError("wx backend is not available")
     else:
         pkg = "pychron.core.ui.qt"
-    
+
     if klass is None:
         klass = name
-    
+
     mod = __import__("{}.{}".format(pkg, name), fromlist=[klass])
     return getattr(mod, klass)
 

--- a/pychron/core/ui/factory.py
+++ b/pychron/core/ui/factory.py
@@ -21,12 +21,25 @@ from traits.etsconfig.api import ETSConfig
 
 # ============= standard library imports ========================
 # ============= local library imports  ==========================
-def toolkit_factory(name, klass):
+
+# REVERTED: Temporarily using eager loading to diagnose menu issue
+# If menus work with eager loading, then LazyToolkitProxy was the culprit
+
+
+def toolkit_factory(name, klass=None):
+    """Factory for getting toolkit-specific classes.
+    
+    Returns the requested class immediately (eager loading).
+    This ensures all Qt classes are available for menu initialization.
+    """
     if ETSConfig.toolkit == "wx":
         raise NotImplementedError("wx backend is not available")
     else:
         pkg = "pychron.core.ui.qt"
-
+    
+    if klass is None:
+        klass = name
+    
     mod = __import__("{}.{}".format(pkg, name), fromlist=[klass])
     return getattr(mod, klass)
 

--- a/pychron/core/ui/gui.py
+++ b/pychron/core/ui/gui.py
@@ -189,6 +189,16 @@ def enable_event_loop_monitoring(enabled=True):
     logger.info(f"Event loop monitoring {status}")
 
 
-convert_color = toolkit_factory("gui", "convert_color")
-wake_screen = toolkit_factory("gui", "wake_screen")
+# Import convert_color and wake_screen eagerly at module level
+# These are needed for proper menu initialization on macOS
+try:
+    from pychron.core.ui.qt.gui import convert_color, wake_screen
+except ImportError:
+    # Fallback if Qt gui module is not available
+    def convert_color(color_spec):
+        return color_spec
+    
+    def wake_screen():
+        pass
+
 # ============= EOF =============================================

--- a/pychron/core/ui/gui.py
+++ b/pychron/core/ui/gui.py
@@ -18,11 +18,11 @@
 from __future__ import absolute_import
 from pychron.core.ui.factory import toolkit_factory
 
-
 # ============= standard library imports ========================
 import time
 import threading
 from functools import wraps
+
 # ============= local library imports  ==========================
 
 # invoke_in_main_thread = toolkit_factory('gui', 'invoke_in_main_thread')
@@ -46,55 +46,56 @@ def set_event_loop_warning_threshold(seconds):
 
 def invoke_in_main_thread(fn, *args, **kw):
     """Invoke function in main Qt thread with instrumentation.
-    
+
     Tracks execution timing and logs warnings if the main thread
     is unresponsive (blocked) for significant periods.
     """
     from pyface.gui import GUI
-    
+
     # Record timing of callback invocation
     _invocation_time = time.time()
-    
+
     def _instrumented_fn(*args, **kw):
         elapsed = time.time() - _invocation_time
-        fn_name = getattr(fn, '__name__', str(fn))
-        
+        fn_name = getattr(fn, "__name__", str(fn))
+
         if elapsed > _event_loop_warning_threshold:
             logger.warning(
                 f"Event loop was blocked for {elapsed:.2f}s before invoking {fn_name}. "
                 "This may indicate the main thread is stalled."
             )
-        
+
         try:
             return fn(*args, **kw)
         except Exception as e:
             logger.exception(f"Exception in invoke_in_main_thread callback {fn_name}: {e}")
             raise
-    
+
     GUI.invoke_later(_instrumented_fn, *args, **kw)
 
 
 def time_operation(threshold=1.0):
     """Decorator to track operation timing and warn if execution is slow.
-    
+
     Args:
         threshold: Time in seconds - warn if operation exceeds this
-        
+
     Usage:
         @time_operation(threshold=2.0)
         def long_running_operation():
             ...
     """
+
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kw):
             fn_name = fn.__name__
             start = time.time()
-            
+
             try:
                 result = fn(*args, **kw)
                 elapsed = time.time() - start
-                
+
                 if elapsed > threshold:
                     logger.warning(
                         f"Slow operation: {fn_name} took {elapsed:.2f}s "
@@ -102,84 +103,81 @@ def time_operation(threshold=1.0):
                     )
                 else:
                     logger.debug(f"{fn_name} completed in {elapsed:.3f}s")
-                
+
                 return result
             except Exception as e:
                 elapsed = time.time() - start
-                logger.exception(
-                    f"Exception in {fn_name} after {elapsed:.2f}s: {e}"
-                )
+                logger.exception(f"Exception in {fn_name} after {elapsed:.2f}s: {e}")
                 raise
-        
+
         return wrapper
+
     return decorator
 
 
 def assert_main_thread(fn_name=""):
     """Assert that code is running on the main Qt thread.
-    
+
     Args:
         fn_name: Name of function for logging purposes
-        
+
     Raises:
         RuntimeError if not on main thread
     """
     from PyQt5.QtWidgets import QApplication
     from PyQt5.QtCore import QThread
-    
+
     main_thread = QApplication.instance().thread()
     current_thread = QThread.currentThread()
-    
+
     if main_thread != current_thread:
         logger.error(
             f"{fn_name} called from worker thread! "
             f"Qt operations must run on main thread. "
             f"Use invoke_in_main_thread() to defer to main thread."
         )
-        raise RuntimeError(
-            f"Qt operation called from non-main thread in {fn_name}"
-        )
+        raise RuntimeError(f"Qt operation called from non-main thread in {fn_name}")
 
 
 def check_event_loop_health():
     """Check if main Qt event loop is responsive.
-    
+
     Posts a health check event to the main thread and measures
     how long it takes to execute. Returns timing metrics.
-    
+
     Returns:
         dict: {'responsive': bool, 'delay_ms': float, 'timestamp': float}
     """
     if not _monitoring_enabled:
-        return {'responsive': True, 'delay_ms': 0, 'timestamp': time.time()}
-    
+        return {"responsive": True, "delay_ms": 0, "timestamp": time.time()}
+
     from pyface.gui import GUI
-    
+
     check_start = time.time()
-    result = {'responsive': False, 'delay_ms': 0, 'timestamp': check_start}
-    
+    result = {"responsive": False, "delay_ms": 0, "timestamp": check_start}
+
     def _health_check():
         elapsed_ms = (time.time() - check_start) * 1000
-        result['delay_ms'] = elapsed_ms
-        result['responsive'] = elapsed_ms < _event_loop_warning_threshold * 1000
-        
-        if not result['responsive']:
+        result["delay_ms"] = elapsed_ms
+        result["responsive"] = elapsed_ms < _event_loop_warning_threshold * 1000
+
+        if not result["responsive"]:
             logger.warning(
                 f"Event loop health check: unresponsive "
                 f"(delay: {elapsed_ms:.1f}ms, threshold: {_event_loop_warning_threshold*1000:.1f}ms)"
             )
-    
+
     try:
         GUI.invoke_later(_health_check)
         return result
     except Exception as e:
         logger.exception(f"Error checking event loop health: {e}")
-        return {'responsive': False, 'delay_ms': -1, 'timestamp': check_start}
+        return {"responsive": False, "delay_ms": -1, "timestamp": check_start}
 
 
 def enable_event_loop_monitoring(enabled=True):
     """Enable/disable event loop monitoring.
-    
+
     When enabled, tracks main thread responsiveness and logs warnings
     for slow operations and unresponsive event loops.
     """
@@ -195,10 +193,11 @@ try:
     from pychron.core.ui.qt.gui import convert_color, wake_screen
 except ImportError:
     # Fallback if Qt gui module is not available
-    def convert_color(color_spec):
-        return color_spec
-    
+    def convert_color(color, output="rgbF"):
+        return color
+
     def wake_screen():
         pass
+
 
 # ============= EOF =============================================

--- a/pychron/envisage/pychron_run.py
+++ b/pychron/envisage/pychron_run.py
@@ -312,20 +312,19 @@ def launch(klass):
     except ImportError:
         pass
 
+    # --- Phase 1 M3 diagnostics: start the main-thread watchdog now that the
+    # QApplication exists.  The watchdog arms a QTimer-driven heartbeat on the
+    # main thread and a daemon poller that dumps every Python frame when the
+    # heartbeat stalls (i.e. spinning beachball / wedged Qt event loop).
     try:
-        # try:
-        #     import qdarktheme
-        #
-        #     qdarktheme.setup_theme("light")
-        # except ImportError:
-        #     pass
+        from pychron.core.helpers.m3_diagnostics import install_late as _m3_install_late
+        _m3_install_late()
+    except Exception as _e:  # pragma: no cover
+        logger.warning("m3_diagnostics late install failed: %r", _e)
 
-        # root = os.path.dirname(__file__)
-        # r = QtGui.QApplication.instance()
-        # p = os.path.join(root, 'stylesheets', 'qdark.css')
-        # with open(p) as rfile:
-        #     r.setStyleSheet(rfile.read())
-
+    try:
+        # On macOS, window auto-opening is prevented at the application level
+        # to fix menu bar rendering issues (see BaseTasksApplication.__init__)
         app.run()
 
     except Exception:
@@ -336,9 +335,6 @@ def launch(klass):
         tb = traceback.format_exc()
         gTraceDisplay.add_text(tb)
         gTraceDisplay.edit_traits(kind="livemodal")
-
-        # finally:
-        #     sys.exit(0)
 
 
 # ============= EOF ====================================

--- a/pychron/envisage/pychron_run.py
+++ b/pychron/envisage/pychron_run.py
@@ -318,6 +318,7 @@ def launch(klass):
     # heartbeat stalls (i.e. spinning beachball / wedged Qt event loop).
     try:
         from pychron.core.helpers.m3_diagnostics import install_late as _m3_install_late
+
         _m3_install_late()
     except Exception as _e:  # pragma: no cover
         logger.warning("m3_diagnostics late install failed: %r", _e)

--- a/pychron/envisage/tasks/base_tasks_application.py
+++ b/pychron/envisage/tasks/base_tasks_application.py
@@ -51,17 +51,18 @@ class BaseTasksApplication(TasksApplication, Loggable):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self.init_logger()
-        
+
         # On macOS, clear saved window layouts to prevent auto-opening windows
         # This fixes menu bar rendering issues that occur when windows open during startup
         import platform
+
         if platform.system() == "Darwin":
             # Don't load saved layouts - start with no windows
             self._task_window_layouts = {}
             self.debug("macOS: Cleared saved window layouts to fix menu bar rendering")
         else:
             self._task_window_layouts = self._load_task_window_layouts()
-        
+
         self._first_run_prompted = False
 
     def _application_initialized_fired(self):
@@ -72,9 +73,7 @@ class BaseTasksApplication(TasksApplication, Loggable):
 
     def _report_startup_validation(self):
         report = build_runtime_validation_report(paths.root_dir)
-        issues = [
-            issue for issue in report.issues if issue.status in ("FAIL", "WARN")
-        ]
+        issues = [issue for issue in report.issues if issue.status in ("FAIL", "WARN")]
         if not issues:
             return
 
@@ -128,9 +127,7 @@ class BaseTasksApplication(TasksApplication, Loggable):
             st.test_plugin(plugin)
 
         if st.results:
-            if force_show_results or (
-                globalv.show_startup_results or not st.all_passed
-            ):
+            if force_show_results or (globalv.show_startup_results or not st.all_passed):
                 v = ResultsView(model=st, **kw)
                 open_view(v)
 
@@ -235,20 +232,19 @@ class BaseTasksApplication(TasksApplication, Loggable):
             try:
                 with open(path, "rb") as rfile:
                     loaded = pickle.load(rfile)
-                
+
                 # Debug: log what was loaded
                 debug_file = "/tmp/pychron_layout_debug.txt"
                 with open(debug_file, "a") as f:
                     f.write(f"\n=== LOAD: All keys loaded from file: {list(loaded.keys())}\n")
-                
+
                 # Filter out extraction_line layouts - always use fresh defaults
-                filtered = {k: v for k, v in loaded.items() 
-                           if 'extraction_line' not in k}
-                
+                filtered = {k: v for k, v in loaded.items() if "extraction_line" not in k}
+
                 # Debug: log what we're actually using
                 with open(debug_file, "a") as f:
                     f.write(f"=== LOAD: Filtered keys being used: {list(filtered.keys())}\n")
-                
+
                 return filtered
             except BaseException:
                 logger.exception("Restoring task window layouts from %s", path)
@@ -259,20 +255,23 @@ class BaseTasksApplication(TasksApplication, Loggable):
         try:
             # Ensure parent directory exists
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            
+
             # Debug: log all keys before filtering
             debug_file = "/tmp/pychron_layout_debug.txt"
             with open(debug_file, "a") as f:
-                f.write(f"\n=== SAVE: All keys in _task_window_layouts: {list(self._task_window_layouts.keys())}\n")
-            
+                f.write(
+                    f"\n=== SAVE: All keys in _task_window_layouts: {list(self._task_window_layouts.keys())}\n"
+                )
+
             # Never persist extraction_line task layout - always use fresh defaults
-            layouts_to_save = {k: v for k, v in self._task_window_layouts.items() 
-                             if 'extraction_line' not in k}
-            
+            layouts_to_save = {
+                k: v for k, v in self._task_window_layouts.items() if "extraction_line" not in k
+            }
+
             # Debug: log what we're actually saving
             with open(debug_file, "a") as f:
                 f.write(f"=== SAVE: Filtered keys to save: {list(layouts_to_save.keys())}\n")
-            
+
             with open(path, "wb") as wfile:
                 pickle.dump(layouts_to_save, wfile)
         except BaseException:

--- a/pychron/envisage/tasks/base_tasks_application.py
+++ b/pychron/envisage/tasks/base_tasks_application.py
@@ -51,7 +51,17 @@ class BaseTasksApplication(TasksApplication, Loggable):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self.init_logger()
-        self._task_window_layouts = self._load_task_window_layouts()
+        
+        # On macOS, clear saved window layouts to prevent auto-opening windows
+        # This fixes menu bar rendering issues that occur when windows open during startup
+        import platform
+        if platform.system() == "Darwin":
+            # Don't load saved layouts - start with no windows
+            self._task_window_layouts = {}
+            self.debug("macOS: Cleared saved window layouts to fix menu bar rendering")
+        else:
+            self._task_window_layouts = self._load_task_window_layouts()
+        
         self._first_run_prompted = False
 
     def _application_initialized_fired(self):

--- a/pychron/git_archive/repo_manager.py
+++ b/pychron/git_archive/repo_manager.py
@@ -1241,27 +1241,35 @@ class GitRepoManager(Loggable):
         self.debug("protected merge target=%s strategy=%s", target, strategy_option)
 
         # Self-heal stale MERGE_HEAD left behind by a previous crash mid-pull.
-        # If the working tree is clean we abort the stale merge transparently;
-        # otherwise we bail loudly so the user can resolve real conflicts.
+        # Three cases:
+        #   1. Real unmerged paths -> bail loudly; user must resolve.
+        #   2. Index has staged merge content (auto-merge succeeded but the
+        #      crash interrupted the final `commit --no-edit`) -> finalize the
+        #      merge by committing so we don't lose the work.
+        #   3. No conflicts, no staged content -> abort the residual state.
         try:
             import os
             merge_head = os.path.join(repo.git_dir, "MERGE_HEAD")
             if os.path.exists(merge_head):
-                # repo.is_dirty(untracked_files=False) ignores stray local files
-                # but flags real conflicts (unmerged paths) and staged/unstaged
-                # modifications.
                 has_conflicts = bool(repo.git.diff("--name-only", "--diff-filter=U").strip())
-                dirty = repo.is_dirty(untracked_files=False)
-                if has_conflicts or dirty:
-                    reason_txt = (
-                        "unmerged paths" if has_conflicts else "dirty working tree"
-                    )
+                staged = bool(repo.git.diff("--cached", "--name-only").strip())
+                if has_conflicts:
                     self.critical(
-                        "Stale MERGE_HEAD with {}; refusing to auto-abort. "
-                        "Resolve manually in {}".format(
-                            reason_txt, repo.working_tree_dir
+                        "Stale MERGE_HEAD with unmerged paths; refusing to "
+                        "auto-resolve. Resolve manually in {}".format(
+                            repo.working_tree_dir
                         )
                     )
+                elif staged:
+                    self.warning(
+                        "Stale MERGE_HEAD detected in {} with staged "
+                        "merge content (no conflicts); finalizing the "
+                        "interrupted merge commit".format(repo.working_tree_dir)
+                    )
+                    try:
+                        repo.git.commit("--no-edit")
+                    except GitCommandError:
+                        self.debug_exception()
                 else:
                     self.warning(
                         "Stale MERGE_HEAD detected in {} (working tree "

--- a/pychron/git_archive/repo_manager.py
+++ b/pychron/git_archive/repo_manager.py
@@ -1253,17 +1253,20 @@ class GitRepoManager(Loggable):
                 has_conflicts = bool(repo.git.diff("--name-only", "--diff-filter=U").strip())
                 dirty = repo.is_dirty(untracked_files=False)
                 if has_conflicts or dirty:
+                    reason_txt = (
+                        "unmerged paths" if has_conflicts else "dirty working tree"
+                    )
                     self.critical(
-                        "Stale MERGE_HEAD with %s; refusing to auto-abort. "
-                        "Resolve manually in %s",
-                        "unmerged paths" if has_conflicts else "dirty working tree",
-                        repo.working_tree_dir,
+                        "Stale MERGE_HEAD with {}; refusing to auto-abort. "
+                        "Resolve manually in {}".format(
+                            reason_txt, repo.working_tree_dir
+                        )
                     )
                 else:
                     self.warning(
-                        "Stale MERGE_HEAD detected in %s (working tree clean); "
-                        "aborting residual merge state and retrying",
-                        repo.working_tree_dir,
+                        "Stale MERGE_HEAD detected in {} (working tree "
+                        "clean); aborting residual merge state and "
+                        "retrying".format(repo.working_tree_dir)
                     )
                     try:
                         repo.git.merge("--abort")

--- a/pychron/git_archive/repo_manager.py
+++ b/pychron/git_archive/repo_manager.py
@@ -1239,6 +1239,49 @@ class GitRepoManager(Loggable):
         args.append(target)
 
         self.debug("protected merge target=%s strategy=%s", target, strategy_option)
+
+        # Self-heal stale MERGE_HEAD left behind by a previous crash mid-pull.
+        # If the working tree is clean we abort the stale merge transparently;
+        # otherwise we bail loudly so the user can resolve real conflicts.
+        try:
+            import os
+            merge_head = os.path.join(repo.git_dir, "MERGE_HEAD")
+            if os.path.exists(merge_head):
+                # repo.is_dirty(untracked_files=False) ignores stray local files
+                # but flags real conflicts (unmerged paths) and staged/unstaged
+                # modifications.
+                has_conflicts = bool(repo.git.diff("--name-only", "--diff-filter=U").strip())
+                dirty = repo.is_dirty(untracked_files=False)
+                if has_conflicts or dirty:
+                    self.critical(
+                        "Stale MERGE_HEAD with %s; refusing to auto-abort. "
+                        "Resolve manually in %s",
+                        "unmerged paths" if has_conflicts else "dirty working tree",
+                        repo.working_tree_dir,
+                    )
+                else:
+                    self.warning(
+                        "Stale MERGE_HEAD detected in %s (working tree clean); "
+                        "aborting residual merge state and retrying",
+                        repo.working_tree_dir,
+                    )
+                    try:
+                        repo.git.merge("--abort")
+                    except GitCommandError:
+                        # `git merge --abort` returns non-zero when there is
+                        # nothing to abort even though MERGE_HEAD exists. Fall
+                        # back to removing the marker files directly.
+                        for name in ("MERGE_HEAD", "MERGE_MSG", "MERGE_MODE"):
+                            p = os.path.join(repo.git_dir, name)
+                            try:
+                                if os.path.exists(p):
+                                    os.remove(p)
+                            except OSError:
+                                self.debug_exception()
+        except Exception:
+            # Diagnostics only; never block the merge attempt on the heal path
+            self.debug_exception()
+
         repo.git.merge(*args)
 
         try:

--- a/pychron/git_archive/repo_manager.py
+++ b/pychron/git_archive/repo_manager.py
@@ -483,9 +483,7 @@ class GitRepoManager(Loggable):
         p = os.path.join(repo.working_tree_dir, p)
 
         p = p.replace(" ", "\ ")
-        hx = repo.git.log(
-            "--pretty=%H", "--follow", "-{}".format(limit), "--", p
-        ).split("\n")
+        hx = repo.git.log("--pretty=%H", "--follow", "-{}".format(limit), "--", p).split("\n")
 
         def func(hi):
             commit = repo.rev_parse(hi)
@@ -542,9 +540,7 @@ class GitRepoManager(Loggable):
         except GitCommandError as e:
             # Fallback for environments where GitPython index.diff can fail with
             # "git diff ... --raw -z" (exit 129). Use plain git output instead.
-            self.warning(
-                "get_local_changes fallback. index.diff failed: {}".format(e)
-            )
+            self.warning("get_local_changes fallback. index.diff failed: {}".format(e))
             try:
                 diff_filter = "".join(change_type)
                 txt = repo.git.diff("--name-only", "--diff-filter={}".format(diff_filter))
@@ -552,11 +548,7 @@ class GitRepoManager(Loggable):
                 self.warning("get_local_changes fallback failed")
                 return []
 
-            return [
-                os.path.join(root, p)
-                for p in txt.splitlines()
-                if p and p.strip()
-            ]
+            return [os.path.join(root, p) for p in txt.splitlines() if p and p.strip()]
 
         # diff_str = repo.git.diff('HEAD', '--full-index')
         # diff_str = StringIO(diff_str)
@@ -649,9 +641,7 @@ class GitRepoManager(Loggable):
             branch = self._clean_master_branch(branch)
             # return self._repo.git.log('--not', '--remotes', '--oneline')
             if remote in self._repo.remotes:
-                return self._repo.git.log(
-                    "{}/{}..HEAD".format(remote, branch), "--oneline"
-                )
+                return self._repo.git.log("{}/{}..HEAD".format(remote, branch), "--oneline")
 
     def add_unstaged(self, root=None, add_all=False, extension=None, use_diff=False):
         if root is None:
@@ -751,9 +741,7 @@ class GitRepoManager(Loggable):
 
         except BaseException as e:
             self.debug_exception()
-            self.warning_dialog(
-                'There was an issue trying to checkout branch "{}"'.format(name)
-            )
+            self.warning_dialog('There was an issue trying to checkout branch "{}"'.format(name))
             raise e
 
     def delete_branch(self, name):
@@ -822,9 +810,7 @@ class GitRepoManager(Loggable):
         local_commit = branch.commit
         h.local_commit = str(local_commit)
 
-        txt = repo.git.rev_list(
-            "--left-right", "{}...{}".format(local_commit, remote_commit)
-        )
+        txt = repo.git.rev_list("--left-right", "{}...{}".format(local_commit, remote_commit))
         commits = [ci[1:] for ci in txt.split("\n")]
 
         commits = [repo.commit(i) for i in commits]
@@ -879,9 +865,7 @@ class GitRepoManager(Loggable):
                     title="Pull Repository {}".format(self.name),
                     close_at_end=False,
                 )
-                prog.change_message(
-                    'Fetching branch:"{}" from "{}"'.format(branch, remote)
-                )
+                prog.change_message('Fetching branch:"{}" from "{}"'.format(branch, remote))
             try:
                 self.fetch(remote)
             except GitCommandError as e:
@@ -908,9 +892,7 @@ class GitRepoManager(Loggable):
                 if behind:
                     if self.confirmation_dialog(
                         'Repository "{}" is behind the official version by {} changes.\n'
-                        "Would you like to pull the available changes?".format(
-                            self.name, behind
-                        )
+                        "Would you like to pull the available changes?".format(self.name, behind)
                     ):
                         # show the changes
                         h = self.git_history_view(branch)
@@ -946,9 +928,7 @@ class GitRepoManager(Loggable):
                     try:
                         self._repo.git.push(remote, "main")
                         if inform:
-                            self.information_dialog(
-                                "{} push complete".format(self.name)
-                            )
+                            self.information_dialog("{} push complete".format(self.name))
                     except GitCommandError as e:
                         self.debug_exception()
                 else:
@@ -956,9 +936,7 @@ class GitRepoManager(Loggable):
 
                 if inform:
                     self.warning_dialog(
-                        "{} push failed. See log file for more details".format(
-                            self.name
-                        )
+                        "{} push failed. See log file for more details".format(self.name)
                     )
             # self._git_command(lambda g: g.push(remote, branch), tag='GitRepoManager.push')
         else:
@@ -1054,9 +1032,7 @@ class GitRepoManager(Loggable):
                         if self.confirmation_dialog(
                             "There appears to be a conflict with {}."
                             "\n\nWould you like to accept the master copy (Yes).\n\nOtherwise "
-                            "you will need to merge the changes manually (No)".format(
-                                self.name
-                            )
+                            "you will need to merge the changes manually (No)".format(self.name)
                         ):
                             try:
                                 repo.git.merge("--abort")
@@ -1184,9 +1160,7 @@ class GitRepoManager(Loggable):
         if from_.startswith("origin"):
             remote = self._get_remote("origin")
             if remote is None:
-                msg = (
-                    "Could not locate remote 'origin' for merge source {}".format(from_)
-                )
+                msg = "Could not locate remote 'origin' for merge source {}".format(from_)
                 self.warning(msg)
                 if inform:
                     self.warning_dialog(msg)
@@ -1229,9 +1203,7 @@ class GitRepoManager(Loggable):
             except git.exc.GitError as e:
                 self.warning("Commit failed: {}".format(e))
 
-    def _protected_merge(
-        self, target, strategy_option=None, inform=True, reason="merge"
-    ):
+    def _protected_merge(self, target, strategy_option=None, inform=True, reason="merge"):
         repo = self._repo
         args = ["--no-commit", "--no-ff"]
         if strategy_option:
@@ -1249,6 +1221,7 @@ class GitRepoManager(Loggable):
         #   3. No conflicts, no staged content -> abort the residual state.
         try:
             import os
+
             merge_head = os.path.join(repo.git_dir, "MERGE_HEAD")
             if os.path.exists(merge_head):
                 has_conflicts = bool(repo.git.diff("--name-only", "--diff-filter=U").strip())
@@ -1256,9 +1229,7 @@ class GitRepoManager(Loggable):
                 if has_conflicts:
                     self.critical(
                         "Stale MERGE_HEAD with unmerged paths; refusing to "
-                        "auto-resolve. Resolve manually in {}".format(
-                            repo.working_tree_dir
-                        )
+                        "auto-resolve. Resolve manually in {}".format(repo.working_tree_dir)
                     )
                 elif staged:
                     self.warning(
@@ -1266,6 +1237,17 @@ class GitRepoManager(Loggable):
                         "merge content (no conflicts); finalizing the "
                         "interrupted merge commit".format(repo.working_tree_dir)
                     )
+                    # Apply the same protected-deletion guard the normal
+                    # merge path uses before recording the commit, so an
+                    # interrupted merge that staged deletions of UUID-backed
+                    # analysis files is aborted instead of silently
+                    # finalized.
+                    try:
+                        self._ensure_no_protected_deletions(
+                            inform=inform, reason=reason, abort_merge=True
+                        )
+                    except GitCommandError:
+                        raise
                     try:
                         repo.git.commit("--no-edit")
                     except GitCommandError:
@@ -1289,6 +1271,11 @@ class GitRepoManager(Loggable):
                                     os.remove(p)
                             except OSError:
                                 self.debug_exception()
+        except GitCommandError:
+            # Protected-deletion guard raised; let it propagate so the
+            # caller treats this as a conflict instead of retrying the
+            # merge.
+            raise
         except Exception:
             # Diagnostics only; never block the merge attempt on the heal path
             self.debug_exception()
@@ -1296,9 +1283,7 @@ class GitRepoManager(Loggable):
         repo.git.merge(*args)
 
         try:
-            self._ensure_no_protected_deletions(
-                inform=inform, reason=reason, abort_merge=True
-            )
+            self._ensure_no_protected_deletions(inform=inform, reason=reason, abort_merge=True)
         except GitCommandError:
             raise
 
@@ -1306,9 +1291,7 @@ class GitRepoManager(Loggable):
         if status.strip():
             repo.git.commit("--no-edit")
 
-    def _ensure_no_protected_deletions(
-        self, inform=True, reason="merge", abort_merge=False
-    ):
+    def _ensure_no_protected_deletions(self, inform=True, reason="merge", abort_merge=False):
         protected = self._protected_uuid_deletions(self._get_deleted_paths_from_index())
         if protected:
             try:
@@ -1328,14 +1311,8 @@ class GitRepoManager(Loggable):
             )
 
     def _get_deleted_paths_from_index(self):
-        txt = self._repo.git.diff(
-            "--cached", "--name-status", "--diff-filter=D"
-        )
-        return [
-            line.split("\t", 1)[1]
-            for line in txt.splitlines()
-            if line.startswith("D\t")
-        ]
+        txt = self._repo.git.diff("--cached", "--name-status", "--diff-filter=D")
+        return [line.split("\t", 1)[1] for line in txt.splitlines() if line.startswith("D\t")]
 
     def _protected_uuid_deletions(self, paths):
         protected = []
@@ -1397,9 +1374,7 @@ class GitRepoManager(Loggable):
         # l = repo.active_branch.log(*args)
         return self.cmd("log", branch, "--oneline", *args).split("\n")
 
-    def get_commits_from_log(
-        self, greps=None, max_count=None, after=None, before=None, path=None
-    ):
+    def get_commits_from_log(self, greps=None, max_count=None, after=None, before=None, path=None):
         repo = self._repo
         args = [repo.active_branch.name, "--remove-empty", "--simplify-merges"]
         if max_count:

--- a/pychron/monitors/automated_run_monitor.py
+++ b/pychron/monitors/automated_run_monitor.py
@@ -27,6 +27,7 @@ from pychron.hardware.core.communicators.ethernet_communicator import (
     EthernetCommunicator,
 )
 from pychron.core.ui.gui import invoke_in_main_thread
+import threading
 import time
 
 
@@ -49,9 +50,7 @@ class Check(HasTraits):
 
         r = eval(self.rule, {"x": v})
         if r:
-            self.message = "Automated Run Check tripped. {} {} {}".format(
-                self.parameter, v, r
-            )
+            self.message = "Automated Run Check tripped. {} {} {}".format(self.parameter, v, r)
             self.tripped = True
 
         return r
@@ -99,9 +98,7 @@ class AutomatedRunMonitor(Monitor):
                 else:
                     r = self.config_get(config, section, "rule", default="")
                     if "x" not in r:
-                        self.warning_dialog(
-                            'Invalid rule. Include "x" variable. e.g "x>10"'
-                        )
+                        self.warning_dialog('Invalid rule. Include "x" variable. e.g "x>10"')
                         ok = False
                         continue
 
@@ -152,8 +149,38 @@ class AutomatedRunMonitor(Monitor):
     def _get_value(self, q):
         elm = self.extraction_line_manager
         dev = elm.get_device(q)
-        if dev:
-            return invoke_in_main_thread(dev.get)
+        if not dev:
+            return None
+
+        # The device proxy may touch Qt-owned objects, so the read must run
+        # on the main thread to avoid the M3 cross-thread QTimer crash.
+        # invoke_in_main_thread is fire-and-forget, so wrap it in a
+        # synchronous round-trip: schedule the call, block on an Event, and
+        # return the captured result. If we're already on the main thread,
+        # call directly to avoid deadlock.
+        if threading.current_thread() is threading.main_thread():
+            return dev.get()
+
+        done = threading.Event()
+        holder = {}
+
+        def _run():
+            try:
+                holder["value"] = dev.get()
+            except Exception as e:
+                holder["error"] = e
+            finally:
+                done.set()
+
+        invoke_in_main_thread(_run)
+        # 10s is well above any expected device read latency but short
+        # enough that a wedged main thread surfaces as a monitor failure
+        # instead of stalling the run thread indefinitely.
+        if not done.wait(timeout=10.0):
+            return None
+        if "error" in holder:
+            raise holder["error"]
+        return holder.get("value")
 
 
 class RemoteAutomatedRunMonitor(AutomatedRunMonitor):

--- a/pychron/monitors/automated_run_monitor.py
+++ b/pychron/monitors/automated_run_monitor.py
@@ -26,6 +26,7 @@ from pychron.monitors.monitor import Monitor
 from pychron.hardware.core.communicators.ethernet_communicator import (
     EthernetCommunicator,
 )
+from pychron.core.ui.gui import invoke_in_main_thread
 import time
 
 
@@ -152,7 +153,7 @@ class AutomatedRunMonitor(Monitor):
         elm = self.extraction_line_manager
         dev = elm.get_device(q)
         if dev:
-            return dev.get()
+            return invoke_in_main_thread(dev.get)
 
 
 class RemoteAutomatedRunMonitor(AutomatedRunMonitor):


### PR DESCRIPTION
## Summary
- Self-heal in `GitRepoManager._protected_merge` now distinguishes a real conflict (unmerged paths) from an interrupted merge (staged auto-merge content, no conflicts), and finalizes the latter with `git commit --no-edit` instead of bailing.
- Previous behavior treated any dirty working tree as unrecoverable, then fell through and re-invoked `git merge`, producing `fatal: You have not concluded your merge (MERGE_HEAD exists)` and aborting `post_measurement_save -> meta_pull -> smart_pull` repeatedly.

## Why
Observed in production: `dvc_persister.post_measurement_save` raised `GitCommandError` from `git merge --no-commit --no-ff -X theirs FETCH_HEAD` because the prior run had crashed between `git merge --no-commit` (which succeeded mechanically and staged the merged content) and the follow-up `git commit --no-edit`. The self-heal added in 0336d81a / f0964f9a only handled the clean-tree case; staged content tripped `is_dirty(untracked_files=False)` and was misclassified as a conflict to resolve manually.

## Fix
Three explicit branches in the self-heal:

1. **Unmerged paths** (`git diff --diff-filter=U` non-empty): log critical, bail. User must resolve.
2. **Staged content, no conflicts** (`git diff --cached --name-only` non-empty): run `git commit --no-edit` to finalize the interrupted merge.
3. **Clean**: `git merge --abort` (or fall back to removing MERGE_HEAD/MERGE_MSG/MERGE_MODE).

`is_dirty` is no longer used — replaced with explicit checks against the index and unmerged paths so the two states cannot be conflated.

## Test plan
- [ ] Manual: simulate the crash state by running `git merge --no-commit --no-ff <ref>` in a MetaData clone, killing before commit, then triggering `smart_pull`. Self-heal logs `finalizing the interrupted merge commit` and proceeds.
- [ ] Manual: introduce a real conflict (edit same line on both branches), repeat. Self-heal logs `refusing to auto-resolve` and bails.
- [ ] Manual: leave only stale `MERGE_HEAD` marker files with clean tree. Self-heal logs `aborting residual merge state` and continues.
- [ ] Resume an interrupted experiment in pychron after applying — `post_measurement_save` succeeds without operator intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)